### PR TITLE
Make use of --frozen-lockfile instead of --pure-lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY package.json yarn.lock $KLICKER_DIR/
 
 # install yarn packages
 RUN set -x \
-  && yarn install --pure-lockfile
+  && yarn install --frozen-lockfile
 
 # inject the entrypoint and make it runnable
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Using `--frozen-lockfile` instead of `--pure-lockfile` when doing yarn install will cause the CI to fail if package.json and yarn.lock are out of sync.