### PR TITLE
[WIP] Implement basic APIs for question pool

### DIFF
--- a/src/resolvers/questions.js
+++ b/src/resolvers/questions.js
@@ -20,21 +20,21 @@ const createQuestionMutation = async (parentValue, { question: { tags, title, ty
   AuthService.isAuthenticated(auth)
 
   // if non-existent tags are passed, they need to be created
-  const fetchTags = await TagModel.find({ _id: { $in: tags } })
+  // const fetchTags = await TagModel.find({ _id: { $in: tags } })
 
   const newQuestion = await new QuestionModel({
-    tags: fetchTags,
+    tags: [],
     title,
     type,
   }).save()
 
-  const user = await UserModel.findById(auth.sub).populate(['questions'])
-  user.questions.push(newQuestion.id)
-
-  user.update({
-    $set: { questions: [...user.questions, newQuestion.id] },
-    $currentDate: { updatedAt: true },
-  })
+  await UserModel.update(
+    { _id: auth.sub },
+    {
+      $push: { questions: newQuestion.id },
+      $currentDate: { updatedAt: true },
+    },
+  )
 
   return newQuestion
 }

--- a/src/resolvers/questions.js
+++ b/src/resolvers/questions.js
@@ -5,36 +5,42 @@ const { QuestionModel, TagModel, UserModel } = require('../models')
 const allQuestionsQuery = async (parentValue, args, { auth }) => {
   AuthService.isAuthenticated(auth)
 
-  const user = await UserModel.findById(auth.sub).populate(['questions'])
+  const user = await UserModel.findById(auth.sub).populate({ path: 'questions', populate: { path: 'tags' } })
+
   return user.questions
 }
 
 const questionQuery = (parentValue, { id }, { auth }) => {
   AuthService.isAuthenticated(auth)
 
-  return QuestionModel.findOne({ id, user: auth.sub })
+  return QuestionModel.findOne({ id, user: auth.sub }).populate({ path: 'questions', populate: { path: 'tags' } })
 }
 
 /* ----- mutations ----- */
-const createQuestionMutation = async (parentValue, { question: { tags, title, type } }, { auth }) => {
+const createQuestionMutation = async (parentValue, { question: { description, tags, title, type } }, { auth }) => {
   AuthService.isAuthenticated(auth)
 
   // if non-existent tags are passed, they need to be created
   // const fetchTags = await TagModel.find({ _id: { $in: tags } })
+  const fetchTags = await TagModel.find({ name: { $in: tags } })
+  const tagIds = fetchTags.map(tag => tag.id)
 
-  const newQuestion = await new QuestionModel({
-    tags: [],
+  const newQuestion = new QuestionModel({
+    tags: [...tagIds],
     title,
     type,
-  }).save()
+    versions: [{ description, options: [], solution: {} }], // add an initial version 0
+  })
 
-  await UserModel.update(
+  const updatedUser = UserModel.update(
     { _id: auth.sub },
     {
       $push: { questions: newQuestion.id },
       $currentDate: { updatedAt: true },
     },
   )
+
+  await Promise.all([newQuestion.save(), updatedUser])
 
   return newQuestion
 }

--- a/src/resolvers/questions.js
+++ b/src/resolvers/questions.js
@@ -5,6 +5,7 @@ const { QuestionModel, TagModel, UserModel } = require('../models')
 const allQuestionsQuery = async (parentValue, args, { auth }) => {
   AuthService.isAuthenticated(auth)
 
+  // TODO: only populate tags if asked for in the query
   const user = await UserModel.findById(auth.sub).populate({ path: 'questions', populate: { path: 'tags' } })
 
   return user.questions
@@ -13,6 +14,7 @@ const allQuestionsQuery = async (parentValue, args, { auth }) => {
 const questionQuery = (parentValue, { id }, { auth }) => {
   AuthService.isAuthenticated(auth)
 
+  // TODO: only populate tags if asked for in the query
   return QuestionModel.findOne({ id, user: auth.sub }).populate({ path: 'questions', populate: { path: 'tags' } })
 }
 

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -19,7 +19,17 @@ const sessionQuery = async (parentValue, { id }, { auth }) => {
 const createSessionMutation = async (parentValue, { session: { name } }, { auth }) => {
   AuthService.isAuthenticated(auth)
 
-  return new SessionModel({ name, user: auth.sub }).save()
+  const newSession = await new SessionModel({ name, user: auth.sub }).save()
+
+  await UserModel.update(
+    { _id: auth.sub },
+    {
+      $push: { sessions: newSession.id },
+      $currentDate: { updatedAt: true },
+    },
+  )
+
+  return newSession
 }
 
 module.exports = {

--- a/src/resolvers/tags.js
+++ b/src/resolvers/tags.js
@@ -15,14 +15,17 @@ const createTagMutation = async (parentValue, { tag: { name } }, { auth }) => {
 
   const newTag = await new TagModel({
     name,
-  }).save()
-
-  const user = await UserModel.findById(auth.sub)
-
-  await user.update({
-    $set: { tags: [...user.tags, newTag.id] },
-    $currentDate: { updatedAt: true },
   })
+
+  const updatedUser = UserModel.update(
+    { _id: auth.sub },
+    {
+      $push: { tags: newTag.id },
+      $currentDate: { updatedAt: true },
+    },
+  )
+
+  await Promise.all([newTag.save(), updatedUser])
 
   return newTag
 }

--- a/src/types/Question.js
+++ b/src/types/Question.js
@@ -10,6 +10,8 @@ const Question = `
     title: String
     type: String
 
+    description: String
+
     tags: [ID]
   }
 
@@ -19,7 +21,9 @@ const Question = `
     title: String!
     type: String!
 
+    instances: [QuestionInstance]
     tags: [Tag]
+    versions: [QuestionVersion]
 
     createdAt: String
     updatedAt: String

--- a/src/types/QuestionInstance.js
+++ b/src/types/QuestionInstance.js
@@ -1,0 +1,16 @@
+/* eslint-disable no-use-before-define */
+
+// HACK: export before require such that circular dependencies can be handled
+module.exports = () => [QuestionInstance]
+
+const QuestionInstance = `
+  type QuestionInstance {
+    id: ID!
+
+    question: Question!
+    version: Int!
+
+    createdAt: String
+    updatedAt: String
+  }
+`

--- a/src/types/QuestionVersion.js
+++ b/src/types/QuestionVersion.js
@@ -1,0 +1,15 @@
+/* eslint-disable no-use-before-define */
+
+// HACK: export before require such that circular dependencies can be handled
+module.exports = () => [QuestionVersion]
+
+const QuestionVersion = `
+  type QuestionVersion {
+    description: String!
+
+    instances: [QuestionInstance]
+
+    createdAt: String
+    updatedAt: String
+  }
+`

--- a/src/types/Tag.js
+++ b/src/types/Tag.js
@@ -8,6 +8,7 @@ const Question = require('./Question')
 const Tag = `
   input TagInput {
     name: String
+    question: ID
   }
 
   type Tag {

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,13 +1,17 @@
 const Feedback = require('./Feedback')
 const Question = require('./Question')
+const QuestionInstance = require('./QuestionInstance')
+const QuestionVersion = require('./QuestionVersion')
 const Session = require('./Session')
 const Tag = require('./Tag')
 const User = require('./User')
 
 module.exports = {
-  allTypes: [Feedback, Question, Session, Tag, User],
+  allTypes: [Feedback, Question, QuestionInstance, QuestionVersion, Session, Tag, User],
   Feedback,
   Question,
+  QuestionInstance,
+  QuestionVersion,
   Session,
   Tag,
   User,


### PR DESCRIPTION
**GENERAL**
- Create basic types for `QuestionInstance` and `QuestionVersion`
- Extend `Question`  with fields for instances and versions
- Extend `QuestionInput` with a description for the 0th version
- Impement `createQuestion` mutation taking into account description and tag names
- Extend `allQuestions` and `question` queries to populate tags

**MISC**
- Extend `TagInput` by the ID of a question, as it is always created together with a question
- Optimize `createTag` mutation using direct updates by id
- Implement valid basic mutation for createSession (same as createQuestion)