### PR TITLE
Improve renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,25 +8,32 @@
   "timezone": "Europe/Zurich",
   "packageRules": [
     {
-      "packagePatterns": [
-        "^babel-eslint",
-        "^eslint",
-        "^prettier",
-        "^pre-commit"
-      ],
-      "groupName": "code style"
+      "packageNames": ["mongodb", "mongoose"],
+      "groupName": "database"
+    },
+    {
+      "packagePatterns": ["^babel-eslint", "^eslint"],
+      "groupName": "eslint",
+      "automerge": "patch"
     },
     {
       "packageNames": ["flow-bin"],
-      "groupName": "flow"
+      "groupName": "flow",
+      "automerge": "patch"
+    },
+    {
+      "packageNames": ["apollo-server-express", "graphql", "graphql-tools"],
+      "groupName": "graphql"
+    },
+    {
+      "packagePatterns": ["^prettier"],
+      "groupName": "prettier",
+      "automerge": "patch"
     },
     {
       "packageNames": ["jest"],
-      "groupName": "test"
-    },
-    {
-      "packageNames": ["mongodb", "mongoose"],
-      "groupName": "database"
+      "groupName": "test",
+      "automerge": "patch"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "automerge": "patch",
   "extends": [":app"],
   "assignees": ["rschlaefli"],
   "labels": ["dependencies"],
@@ -14,12 +15,12 @@
     {
       "packagePatterns": ["^babel-eslint", "^eslint"],
       "groupName": "eslint",
-      "automerge": "patch"
+      "automerge": "minor"
     },
     {
       "packageNames": ["flow-bin"],
       "groupName": "flow",
-      "automerge": "patch"
+      "automerge": "minor"
     },
     {
       "packageNames": ["apollo-server-express", "graphql", "graphql-tools"],
@@ -28,12 +29,12 @@
     {
       "packagePatterns": ["^prettier"],
       "groupName": "prettier",
-      "automerge": "patch"
+      "automerge": "minor"
     },
     {
       "packageNames": ["jest"],
       "groupName": "test",
-      "automerge": "patch"
+      "automerge": "minor"
     }
   ]
 }


### PR DESCRIPTION
- Enable global automerge for `patch` updates
- Improve grouping of dependencies
- Enable automerge for `minor` updates for testing, code style and CI dependencies