### PR TITLE
Basic session operations

### DIFF
--- a/src/models/Session.js
+++ b/src/models/Session.js
@@ -27,6 +27,8 @@ const Session = new mongoose.Schema({
   confusionTS: [ConfusionTimeStep],
   feedbacks: [Feedback],
 
+  activeInstance: { type: ObjectId, ref: 'QuestionInstance' },
+
   createdAt: { type: Date, default: Date.now() },
   updatedAt: { type: Date, default: Date.now() },
 })

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -25,6 +25,8 @@ const User = new mongoose.Schema({
   questions: [{ type: ObjectId, ref: 'Question' }],
   sessions: [{ type: ObjectId, ref: 'Session' }],
 
+  runningSession: { type: ObjectId, ref: 'Session' },
+
   createdAt: { type: Date, default: Date.now() },
   updatedAt: { type: Date, default: Date.now() },
 })

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,10 +1,12 @@
 const QuestionModel = require('./Question')
+const QuestionInstanceModel = require('./QuestionInstance')
 const SessionModel = require('./Session')
 const TagModel = require('./Tag')
 const UserModel = require('./User')
 
 module.exports = {
   QuestionModel,
+  QuestionInstanceModel,
   SessionModel,
   TagModel,
   UserModel,

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -20,16 +20,29 @@ const sessionQuery = async (parentValue, { id }, { auth }) => {
 const createSessionMutation = async (parentValue, { session: { name, blocks } }, { auth }) => {
   AuthService.isAuthenticated(auth)
 
-  const newSession = await SessionService.createSession({
+  return SessionService.createSession({
     name,
     questionBlocks: blocks,
     user: auth.sub,
   })
-  return newSession
+}
+
+const startSessionMutation = async (parentValue, { id }, { auth }) => {
+  AuthService.isAuthenticated(auth)
+
+  return SessionService.startSession({ id, userId: auth.sub })
+}
+
+const endSessionMutation = async (parentValue, { id }, { auth }) => {
+  AuthService.isAuthenticated(auth)
+
+  return SessionService.endSession({ id, userId: auth.sub })
 }
 
 module.exports = {
   allSessions: allSessionsQuery,
   createSession: createSessionMutation,
+  endSession: endSessionMutation,
   session: sessionQuery,
+  startSession: startSessionMutation,
 }

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -1,5 +1,6 @@
 const AuthService = require('../services/auth')
-const { QuestionInstanceModel, SessionModel, UserModel } = require('../models')
+const SessionService = require('../services/sessions')
+const { SessionModel, UserModel } = require('../models')
 
 /* ----- queries ----- */
 const allSessionsQuery = async (parentValue, args, { auth }) => {
@@ -19,50 +20,7 @@ const sessionQuery = async (parentValue, { id }, { auth }) => {
 const createSessionMutation = async (parentValue, { session: { name, blocks } }, { auth }) => {
   AuthService.isAuthenticated(auth)
 
-  // initialize a store for newly created instance models
-  let instances = []
-
-  // pass through all the question block in params
-  // create question instances for all questions within
-  const questionBlocks = blocks.map(block => ({
-    questions: block.questions.map((question) => {
-      // create a new question instance model
-      const instance = new QuestionInstanceModel({
-        question: question.id,
-        user: auth.sub,
-        version: 0,
-      })
-
-      // append the new question instance to the store
-      instances = [...instances, instance]
-
-      // return only the id of the new instance
-      return instance.id
-    }),
-  }))
-
-  // create a new session model
-  // pass in the list of blocks created above
-  const newSession = new SessionModel({
-    name,
-    blocks: questionBlocks,
-    user: auth.sub,
-  }).save()
-
-  // save everything at once
-  await Promise.all([
-    ...instances.map(instance => instance.save()),
-    newSession,
-    UserModel.update(
-      { _id: auth.sub },
-      {
-        $push: { sessions: newSession.id },
-        $currentDate: { updatedAt: true },
-      },
-    ),
-  ])
-
-  // return the data of the new session
+  const newSession = await SessionService.createSession({ name, questionBlocks: blocks, user: auth.sub })
   return newSession
 }
 

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -20,7 +20,11 @@ const sessionQuery = async (parentValue, { id }, { auth }) => {
 const createSessionMutation = async (parentValue, { session: { name, blocks } }, { auth }) => {
   AuthService.isAuthenticated(auth)
 
-  const newSession = await SessionService.createSession({ name, questionBlocks: blocks, user: auth.sub })
+  const newSession = await SessionService.createSession({
+    name,
+    questionBlocks: blocks,
+    user: auth.sub,
+  })
   return newSession
 }
 

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -1,5 +1,5 @@
 const AuthService = require('../services/auth')
-const { SessionModel, UserModel } = require('../models')
+const { QuestionInstanceModel, SessionModel, UserModel } = require('../models')
 
 /* ----- queries ----- */
 const allSessionsQuery = async (parentValue, args, { auth }) => {
@@ -16,19 +16,53 @@ const sessionQuery = async (parentValue, { id }, { auth }) => {
 }
 
 /* ----- mutations ----- */
-const createSessionMutation = async (parentValue, { session: { name } }, { auth }) => {
+const createSessionMutation = async (parentValue, { session: { name, blocks } }, { auth }) => {
   AuthService.isAuthenticated(auth)
 
-  const newSession = await new SessionModel({ name, user: auth.sub }).save()
+  // initialize a store for newly created instance models
+  let instances = []
 
-  await UserModel.update(
-    { _id: auth.sub },
-    {
-      $push: { sessions: newSession.id },
-      $currentDate: { updatedAt: true },
-    },
-  )
+  // pass through all the question block in params
+  // create question instances for all questions within
+  const questionBlocks = blocks.map(block => ({
+    questions: block.questions.map((question) => {
+      // create a new question instance model
+      const instance = new QuestionInstanceModel({
+        question: question.id,
+        user: auth.sub,
+        version: 0,
+      })
 
+      // append the new question instance to the store
+      instances = [...instances, instance]
+
+      // return only the id of the new instance
+      return instance.id
+    }),
+  }))
+
+  // create a new session model
+  // pass in the list of blocks created above
+  const newSession = new SessionModel({
+    name,
+    blocks: questionBlocks,
+    user: auth.sub,
+  }).save()
+
+  // save everything at once
+  await Promise.all([
+    ...instances.map(instance => instance.save()),
+    newSession,
+    UserModel.update(
+      { _id: auth.sub },
+      {
+        $push: { sessions: newSession.id },
+        $currentDate: { updatedAt: true },
+      },
+    ),
+  ])
+
+  // return the data of the new session
   return newSession
 }
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,7 +1,9 @@
 const { makeExecutableSchema } = require('graphql-tools')
 
 const { allQuestions, createQuestion, question } = require('./resolvers/questions')
-const { allSessions, createSession, session } = require('./resolvers/sessions')
+const {
+  allSessions, createSession, endSession, session, startSession,
+} = require('./resolvers/sessions')
 const { allTags, createTag } = require('./resolvers/tags')
 const { createUser, login, user } = require('./resolvers/users')
 const { allTypes } = require('./types')
@@ -28,8 +30,13 @@ const typeDefs = [
 
   type Mutation {
     createQuestion(question: QuestionInput): Question
+
     createSession(session: SessionInput): Session
+    startSession(id: ID): Session
+    endSession(id: ID): Session
+
     createTag(tag: TagInput): Tag
+
     createUser(user: UserInput): User
     login(email: String, password: String): User
   }
@@ -53,7 +60,9 @@ const resolvers = {
     createSession,
     createTag,
     createUser,
+    endSession,
     login,
+    startSession,
   },
 }
 

--- a/src/services/__snapshots__/sessions.test.js.snap
+++ b/src/services/__snapshots__/sessions.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SessionService createSession allows creating a valid session 1`] = `
+
+    Name: hello world
+    Status: 0
+    User: 59b11befc9eaa334b8340239
+
+    Blocks:
+      { status: 0,
+  timeLimit: -1,
+  showSolutions: false,
+  questions: [ 59cbb17300d04d0680e97b88, 59cbb17300d04d0680e97b89 ],
+  createdAt: 2017-09-27T14:10:58.504Z,
+  updatedAt: 2017-09-27T14:10:58.504Z,
+  _id: 59cbb17300d04d0680e97b8d },{ status: 0,
+  timeLimit: -1,
+  showSolutions: false,
+  questions: [ 59cbb17300d04d0680e97b8a ],
+  createdAt: 2017-09-27T14:10:58.504Z,
+  updatedAt: 2017-09-27T14:10:58.504Z,
+  _id: 59cbb17300d04d0680e97b8c }
+
+    Settings:
+      { isConfusionBarometerActive: false,
+  isFeedbackChannelActive: false,
+  isFeedbackChannelPublic: false }
+  
+`;

--- a/src/services/__snapshots__/sessions.test.js.snap
+++ b/src/services/__snapshots__/sessions.test.js.snap
@@ -45,6 +45,26 @@ exports[`SessionService endSession allows ending a running session 1`] = `
   
 `;
 
+exports[`SessionService endSession returns on an already completed session 1`] = `
+
+    Name: testing session
+    Status: 2
+    User: 59b11befc9eaa334b8340239
+
+    Blocks: 
+      Show solutions: false
+      Status: 0
+      Time limit: -1
+      Number of instances: 1
+    
+
+    Settings:
+      { isConfusionBarometerActive: false,
+  isFeedbackChannelActive: false,
+  isFeedbackChannelPublic: false }
+  
+`;
+
 exports[`SessionService startSession allows starting a created session 1`] = `
 
     Name: testing session

--- a/src/services/__snapshots__/sessions.test.js.snap
+++ b/src/services/__snapshots__/sessions.test.js.snap
@@ -6,20 +6,57 @@ exports[`SessionService createSession allows creating a valid session 1`] = `
     Status: 0
     User: 59b11befc9eaa334b8340239
 
-    Blocks:
-      { status: 0,
-  timeLimit: -1,
-  showSolutions: false,
-  questions: [ 59cbb17300d04d0680e97b88, 59cbb17300d04d0680e97b89 ],
-  createdAt: 2017-09-27T14:10:58.504Z,
-  updatedAt: 2017-09-27T14:10:58.504Z,
-  _id: 59cbb17300d04d0680e97b8d },{ status: 0,
-  timeLimit: -1,
-  showSolutions: false,
-  questions: [ 59cbb17300d04d0680e97b8a ],
-  createdAt: 2017-09-27T14:10:58.504Z,
-  updatedAt: 2017-09-27T14:10:58.504Z,
-  _id: 59cbb17300d04d0680e97b8c }
+    Blocks: 
+      Show solutions: false
+      Status: 0
+      Time limit: -1
+      Number of instances: 2
+    ,
+      Show solutions: false
+      Status: 0
+      Time limit: -1
+      Number of instances: 1
+    
+
+    Settings:
+      { isConfusionBarometerActive: false,
+  isFeedbackChannelActive: false,
+  isFeedbackChannelPublic: false }
+  
+`;
+
+exports[`SessionService endSession allows ending a running session 1`] = `
+
+    Name: testing session
+    Status: 2
+    User: 59b11befc9eaa334b8340239
+
+    Blocks: 
+      Show solutions: false
+      Status: 0
+      Time limit: -1
+      Number of instances: 1
+    
+
+    Settings:
+      { isConfusionBarometerActive: false,
+  isFeedbackChannelActive: false,
+  isFeedbackChannelPublic: false }
+  
+`;
+
+exports[`SessionService startSession allows starting a created session 1`] = `
+
+    Name: testing session
+    Status: 1
+    User: 59b11befc9eaa334b8340239
+
+    Blocks: 
+      Show solutions: false
+      Status: 0
+      Time limit: -1
+      Number of instances: 1
+    
 
     Settings:
       { isConfusionBarometerActive: false,

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,7 +1,7 @@
 const bcrypt = require('bcryptjs')
 const JWT = require('jsonwebtoken')
 
-const UserModel = require('../models/User')
+const { UserModel } = require('../models')
 
 const dev = process.env.NODE_ENV !== 'production'
 

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -5,12 +5,14 @@ const { UserModel } = require('../models')
 
 const dev = process.env.NODE_ENV !== 'production'
 
+// check whether an authentication object is valid
 const isAuthenticated = (auth) => {
   if (!auth || !auth.sub) {
     throw new Error('INVALID_LOGIN')
   }
 }
 
+// check whether a JWT is valid
 const isValidJWT = (jwt, secret) => {
   try {
     JWT.verify(jwt, secret)
@@ -20,6 +22,7 @@ const isValidJWT = (jwt, secret) => {
   }
 }
 
+// signup a new user
 // make this an async function such that it returns a promise
 // we can later use this promise as a return value for resolvers or similar
 const signup = async (email, password, shortname) => {
@@ -44,6 +47,7 @@ const signup = async (email, password, shortname) => {
   throw new Error('SIGNUP_FAILED')
 }
 
+// login an existing user
 // make this an async function such that it returns a promise
 // we can later use this promise as a return value for resolvers or similar
 const login = async (res, email, password) => {

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -67,13 +67,15 @@ const login = async (res, email, password) => {
   // httpOnly: don't allow interactions from javascript
   // secure: whether the cookie should only be sent over https
   // TODO: set other important cookie settings
-  res.cookie('jwt', jwt, {
-    domain: process.env.APP_DOMAIN,
-    httpOnly: true,
-    maxAge: 86400000,
-    path: '/graphql',
-    secure: !dev,
-  })
+  if (res && res.cookie) {
+    res.cookie('jwt', jwt, {
+      domain: process.env.APP_DOMAIN,
+      httpOnly: true,
+      maxAge: 86400000,
+      path: '/graphql',
+      secure: !dev,
+    })
+  }
 
   // resolve with data about the user
   return user

--- a/src/services/auth.test.js
+++ b/src/services/auth.test.js
@@ -10,8 +10,8 @@ const {
 const { UserModel } = require('../models')
 
 describe('AuthService', () => {
-  beforeAll(() => {
-    mongoose.connect('mongodb://klicker:klicker@ds161042.mlab.com:61042/klicker-dev')
+  beforeAll(async () => {
+    await mongoose.connect('mongodb://klicker:klicker@ds161042.mlab.com:61042/klicker-dev')
   })
   afterAll((done) => {
     mongoose.disconnect(done)

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1,5 +1,6 @@
 const { QuestionInstanceModel, SessionModel, UserModel } = require('../models')
 
+// create a new session
 const createSession = async ({ name, questionBlocks, user }) => {
   // ensure that the session contains at least one question block
   if (questionBlocks.length === 0) {
@@ -53,6 +54,7 @@ const createSession = async ({ name, questionBlocks, user }) => {
   return newSession
 }
 
+// start an existing session
 const startSession = async ({ id, userId }) => {
   // TODO: hydrate caches?
   // TODO: ...
@@ -90,6 +92,7 @@ const startSession = async ({ id, userId }) => {
   return session
 }
 
+// end (complete) an existing session
 const endSession = async ({ id, userId }) => {
   // TODO: date compression? data aggregation?
   // TODO: cleanup caches?

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1,12 +1,18 @@
 const { QuestionInstanceModel, SessionModel, UserModel } = require('../models')
 
 const createSession = async ({ name, questionBlocks, user }) => {
+  // ensure that the session contains at least one question block
+  if (questionBlocks.length === 0) {
+    throw new Error('EMPTY_SESSION')
+  }
+
   // initialize a store for newly created instance models
   let instances = []
 
-  // pass through all the question block in params
+  // pass through all the question blocks in params
+  // skip any blocks that are empty (erroneous blocks)
   // create question instances for all questions within
-  const blocks = questionBlocks.map(block => ({
+  const blocks = questionBlocks.filter(block => block.questions.length > 0).map(block => ({
     questions: block.questions.map((question) => {
       // create a new question instance model
       const instance = new QuestionInstanceModel({

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -1,0 +1,55 @@
+const { QuestionInstanceModel, SessionModel, UserModel } = require('../models')
+
+const createSession = async ({ name, questionBlocks, user }) => {
+  // initialize a store for newly created instance models
+  let instances = []
+
+  // pass through all the question block in params
+  // create question instances for all questions within
+  const blocks = questionBlocks.map(block => ({
+    questions: block.questions.map((question) => {
+      // create a new question instance model
+      const instance = new QuestionInstanceModel({
+        question: question.id,
+        user,
+        version: 0,
+      })
+
+      // append the new question instance to the store
+      instances = [...instances, instance]
+
+      // return only the id of the new instance
+      return instance.id
+    }),
+  }))
+
+  // create a new session model
+  // pass in the list of blocks created above
+  const newSession = new SessionModel({
+    name,
+    blocks,
+    user,
+  })
+
+  // save everything at once
+  await Promise.all([
+    ...instances.map(instance => instance.save()),
+    newSession.save(),
+    UserModel.update(
+      { _id: user },
+      {
+        $push: { sessions: newSession.id },
+        $currentDate: { updatedAt: true },
+      },
+    ),
+  ])
+
+  return newSession
+}
+
+const startSession = () => ({})
+
+module.exports = {
+  createSession,
+  startSession,
+}

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -97,6 +97,11 @@ const endSession = async ({ id, userId }) => {
 
   const session = await SessionModel.findById(id)
 
+  // if the session is not yet running, throw an error
+  if (session.status === 0) {
+    throw new Error('SESSION_NOT_STARTED')
+  }
+
   // if the session was already completed, return it
   if (session.status === 2) {
     return session

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -53,9 +53,54 @@ const createSession = async ({ name, questionBlocks, user }) => {
   return newSession
 }
 
-const startSession = () => ({})
+const startSession = async ({ id }) => {
+  // TODO: hydrate caches?
+  // TODO: ...
+
+  const session = await SessionModel.findById(id)
+
+  // if the session is already running, return it
+  if (session.status === 1) {
+    return session
+  }
+
+  // if the session was already completed, throw an error
+  if (session.status === 2) {
+    throw new Error('SESSION_ALREADY_COMPLETED')
+  }
+
+  session.status = 1
+
+  await session.save({
+    // TODO: calculate the id of the active instance
+    $currentDate: { updatedAt: true },
+  })
+
+  return session
+}
+
+const endSession = async ({ id }) => {
+  // TODO: date compression?
+  // TODO: cleanup caches?
+  // TODO: ...
+
+  const session = await SessionModel.findById(id)
+
+  if (session.status === 2) {
+    return session
+  }
+
+  session.status = 2
+
+  await session.save({
+    $currentDate: { updatedAt: true },
+  })
+
+  return session
+}
 
 module.exports = {
   createSession,
   startSession,
+  endSession,
 }

--- a/src/services/sessions.test.js
+++ b/src/services/sessions.test.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose')
+// const JWT = require('jsonwebtoken')
+
+const SessionService = require('./sessions')
+
+mongoose.Promise = Promise
+process.env.APP_SECRET = 'hello-world'
+
+describe('SessionService', () => {
+  beforeAll(() => {
+    mongoose.connect('mongodb://klicker:klicker@ds161042.mlab.com:61042/klicker-dev')
+  })
+  afterAll((done) => {
+    mongoose.disconnect(done)
+  })
+
+  describe('createSession', () => {
+
+  })
+})

--- a/src/services/sessions.test.js
+++ b/src/services/sessions.test.js
@@ -119,9 +119,15 @@ describe('SessionService', () => {
     })
 
     it('prevents starting an already completed session', async () => {
-      await SessionService.endSession({ id: preparedSession.id, userId: user.id })
+      await SessionService.endSession({
+        id: preparedSession.id,
+        userId: user.id,
+      })
 
-      expect(SessionService.startSession({ id: preparedSession.id, userId: user.id })).rejects.toEqual(new Error('SESSION_ALREADY_COMPLETED'))
+      expect(SessionService.startSession({
+        id: preparedSession.id,
+        userId: user.id,
+      })).rejects.toEqual(new Error('SESSION_ALREADY_COMPLETED'))
     })
   })
 
@@ -133,7 +139,10 @@ describe('SessionService', () => {
     })
 
     it('prevents completing a newly created session', async () => {
-      expect(SessionService.endSession({ id: preparedSession.id, userId: user.id })).rejects.toEqual(new Error('SESSION_NOT_STARTED'))
+      expect(SessionService.endSession({
+        id: preparedSession.id,
+        userId: user.id,
+      })).rejects.toEqual(new Error('SESSION_NOT_STARTED'))
     })
 
     it('allows ending a running session', async () => {
@@ -142,14 +151,20 @@ describe('SessionService', () => {
         userId: user.id,
       })
 
-      const endedSession = await SessionService.endSession({ id: preparedSession.id, userId: user.id })
+      const endedSession = await SessionService.endSession({
+        id: preparedSession.id,
+        userId: user.id,
+      })
 
       expect(endedSession.status).toEqual(2)
       expect(endedSession).toMatchSnapshot()
     })
 
     it('returns on an already completed session', async () => {
-      const session = await SessionService.endSession({ id: preparedSession.id, userId: user.id })
+      const session = await SessionService.endSession({
+        id: preparedSession.id,
+        userId: user.id,
+      })
 
       expect(session).toMatchSnapshot()
     })

--- a/src/services/sessions.test.js
+++ b/src/services/sessions.test.js
@@ -26,15 +26,16 @@ expect.addSnapshotSerializer({
   `,
 })
 
-const prepareSession = user => SessionService.createSession({
-  name: 'testing session',
-  questionBlocks: [
-    {
-      questions: [{ id: '59b1481857f3c34af09a4736' }],
-    },
-  ],
-  user,
-})
+const prepareSession = user =>
+  SessionService.createSession({
+    name: 'testing session',
+    questionBlocks: [
+      {
+        questions: [{ id: '59b1481857f3c34af09a4736' }],
+      },
+    ],
+    user,
+  })
 
 describe('SessionService', () => {
   let user
@@ -107,6 +108,7 @@ describe('SessionService', () => {
     it('allows starting a created session', async () => {
       const startedSession = await SessionService.startSession({
         id: preparedSession.id,
+        userId: user.id,
       })
 
       expect(startedSession.status).toEqual(1)
@@ -114,9 +116,9 @@ describe('SessionService', () => {
     })
 
     it('prevents starting an already completed session', async () => {
-      await SessionService.endSession({ id: preparedSession.id })
+      await SessionService.endSession({ id: preparedSession.id, userId: user.id })
 
-      expect(SessionService.startSession({ id: preparedSession.id })).rejects.toEqual(new Error('SESSION_ALREADY_COMPLETED'))
+      expect(SessionService.startSession({ id: preparedSession.id, userId: user.id })).rejects.toEqual(new Error('SESSION_ALREADY_COMPLETED'))
     })
   })
 
@@ -130,9 +132,10 @@ describe('SessionService', () => {
     it('allows ending a running session', async () => {
       await SessionService.startSession({
         id: preparedSession.id,
+        userId: user.id,
       })
 
-      const endedSession = await SessionService.endSession({ id: preparedSession.id })
+      const endedSession = await SessionService.endSession({ id: preparedSession.id, userId: user.id })
 
       expect(endedSession.status).toEqual(2)
       expect(endedSession).toMatchSnapshot()

--- a/src/services/sessions.test.js
+++ b/src/services/sessions.test.js
@@ -1,20 +1,85 @@
 const mongoose = require('mongoose')
 // const JWT = require('jsonwebtoken')
 
+const AuthService = require('./auth')
 const SessionService = require('./sessions')
 
 mongoose.Promise = Promise
 process.env.APP_SECRET = 'hello-world'
 
+expect.addSnapshotSerializer({
+  test: val => val.id && val.blocks && val.name && val.status >= 0 && val.settings && val.user,
+  print: val => `
+    Name: ${val.name}
+    Status: ${val.status}
+    User: ${val.user}
+
+    Blocks:
+      ${val.blocks}
+
+    Settings:
+      ${val.settings}
+  `,
+})
+
 describe('SessionService', () => {
-  beforeAll(() => {
-    mongoose.connect('mongodb://klicker:klicker@ds161042.mlab.com:61042/klicker-dev')
+  let user
+
+  beforeAll(async () => {
+    // connect to the database
+    await mongoose.connect('mongodb://klicker:klicker@ds161042.mlab.com:61042/klicker-dev')
+    // login as a test user
+    user = await AuthService.login(null, 'roland.schlaefli@bf.uzh.ch', 'abcdabcd')
   })
   afterAll((done) => {
     mongoose.disconnect(done)
+    user = undefined
   })
 
   describe('createSession', () => {
+    it('prevents creating sessions without question blocks', async () => {
+      expect(SessionService.createSession({
+        name: 'empty session',
+        questionBlocks: [],
+        user: user.id,
+      })).rejects.toEqual(new Error('EMPTY_SESSION'))
+    })
 
+    it('skips over question blocks without questions', async () => {
+      const newSession = await SessionService.createSession({
+        name: 'session with an empty block',
+        questionBlocks: [
+          {
+            questions: [{ id: '59b13d288b01b731583850ab' }, { id: '59b13d6f8b01b731583850af' }],
+          },
+          {
+            questions: [],
+          },
+          {
+            questions: [{ id: '59b1481857f3c34af09a4736' }],
+          },
+        ],
+        user: user.id,
+      })
+
+      expect(newSession.blocks.length).toEqual(2)
+    })
+
+    it('allows creating a valid session', async () => {
+      const newSession = await SessionService.createSession({
+        name: 'hello world',
+        questionBlocks: [
+          {
+            questions: [{ id: '59b13d288b01b731583850ab' }, { id: '59b13d6f8b01b731583850af' }],
+          },
+          {
+            questions: [{ id: '59b1481857f3c34af09a4736' }],
+          },
+        ],
+        user: user.id,
+      })
+
+      expect(newSession).toMatchSnapshot()
+    })
   })
 })

--- a/src/types/Session.js
+++ b/src/types/Session.js
@@ -8,8 +8,8 @@ const QuestionInstance = require('./QuestionInstance')
 
 const Session = `
   enum SessionStatus {
-    CREATED,
-    RUNNING,
+    CREATED
+    RUNNING
     COMPLETED
   }
 
@@ -17,13 +17,13 @@ const Session = `
     id: ID!
   }
 
-  input QuestionBlockInput {
+  input Session_QuestionBlockInput {
     questions: [Session_QuestionInput]
   }
 
   input SessionInput {
     name: String!
-    blocks: [QuestionBlockInput]!
+    blocks: [Session_QuestionBlockInput]!
   }
 
   type SessionSettings {

--- a/src/types/Session.js
+++ b/src/types/Session.js
@@ -1,9 +1,10 @@
 /* eslint-disable no-use-before-define */
 
 // HACK: export before require such that circular dependencies can be handled
-module.exports = () => [Session, Feedback]
+module.exports = () => [Session, Feedback, QuestionInstance]
 
 const Feedback = require('./Feedback')
+const QuestionInstance = require('./QuestionInstance')
 
 const Session = `
   enum SessionStatus {
@@ -12,14 +13,27 @@ const Session = `
     COMPLETED
   }
 
+  input Session_QuestionInput {
+    id: ID!
+  }
+
+  input QuestionBlockInput {
+    questions: [Session_QuestionInput]
+  }
+
+  input SessionInput {
+    name: String!
+    blocks: [QuestionBlockInput]!
+  }
+
   type SessionSettings {
     isConfusionBarometerActive: Boolean
     isFeedbackChannelActive: Boolean
     isFeedbackChannelPublic: Boolean
   }
 
-  input SessionInput {
-    name: String
+  type QuestionBlock {
+    questions: [QuestionInstance]
   }
 
   type Session {
@@ -29,6 +43,7 @@ const Session = `
     status: Int!
     settings: SessionSettings
 
+    blocks: [QuestionBlock]
     feedbacks: [Feedback]
 
     createdAt: String


### PR DESCRIPTION
- Add a basic `SessionService` that handles operations concerning sessions
  - Creates new sessions and handles question instance creations
  - Starts existing sessions
  - Ends existing sessions
- Add tests for the above service
- Add basic GraphQL resolvers and mutations that make use of the above service