### PR TITLE
Restructuring GraphQL for best practice

### DIFF
--- a/src/models/Question.js
+++ b/src/models/Question.js
@@ -7,7 +7,7 @@ const QuestionVersion = require('./QuestionVersion')
 const Question = new mongoose.Schema({
   title: { type: String, required: true },
   type: { type: String, enum: ['SC'] },
-  user: { type: ObjectId, ref: 'User' },
+  user: { type: ObjectId, ref: 'User', required: true },
 
   versions: [QuestionVersion],
   instances: [{ type: ObjectId, ref: 'QuestionInstance' }],

--- a/src/models/QuestionBlock.js
+++ b/src/models/QuestionBlock.js
@@ -13,7 +13,7 @@ const QuestionBlock = new mongoose.Schema({
   timeLimit: { type: Number, default: -1, min: -1 },
   showSolutions: { type: Boolean, default: false },
 
-  questions: [{ type: ObjectId, ref: 'QuestionInstance' }],
+  instances: [{ type: ObjectId, ref: 'QuestionInstance' }],
 
   createdAt: { type: Date, default: Date.now() },
   updatedAt: { type: Date, default: Date.now() },

--- a/src/models/QuestionInstance.js
+++ b/src/models/QuestionInstance.js
@@ -3,8 +3,8 @@ const mongoose = require('mongoose')
 const { ObjectId } = mongoose.Schema.Types
 
 const QuestionInstance = new mongoose.Schema({
-  question: { type: ObjectId, required: true, ref: 'Question' },
-  user: { type: ObjectId, ref: 'User' },
+  question: { type: ObjectId, ref: 'Question', required: true },
+  user: { type: ObjectId, ref: 'User', required: true },
   version: { type: Number, required: true, min: 0 },
 
   responses: [{ type: Object }],

--- a/src/models/Session.js
+++ b/src/models/Session.js
@@ -21,7 +21,7 @@ const Session = new mongoose.Schema({
     isFeedbackChannelActive: { type: Boolean, default: false },
     isFeedbackChannelPublic: { type: Boolean, default: false },
   },
-  user: { type: ObjectId, ref: 'User' },
+  user: { type: ObjectId, ref: 'User', required: true },
 
   blocks: [QuestionBlock],
   confusionTS: [ConfusionTimeStep],

--- a/src/models/Tag.js
+++ b/src/models/Tag.js
@@ -4,7 +4,7 @@ const { ObjectId } = mongoose.Schema.Types
 
 const Tag = new mongoose.Schema({
   name: { type: String, required: true, index: true },
-  user: { type: ObjectId, ref: 'User' },
+  user: { type: ObjectId, ref: 'User', required: true },
 
   questions: [{ type: ObjectId, ref: 'Question' }],
 

--- a/src/resolvers/questions.js
+++ b/src/resolvers/questions.js
@@ -1,30 +1,16 @@
-const AuthService = require('../services/auth')
 const QuestionService = require('../services/questions')
 const { QuestionModel, UserModel } = require('../models')
 
 /* ----- queries ----- */
 const allQuestionsQuery = async (parentValue, args, { auth }) => {
-  AuthService.isAuthenticated(auth)
-
-  // TODO: only populate tags if asked for in the query
-  const user = await UserModel.findById(auth.sub).populate({ path: 'questions', populate: { path: 'tags' } })
-
+  const user = await UserModel.findById(auth.sub).populate({ path: 'questions' })
   return user.questions
 }
 
-const questionQuery = (parentValue, { id }, { auth }) => {
-  AuthService.isAuthenticated(auth)
-
-  // TODO: only populate tags if asked for in the query
-  return QuestionModel.findOne({ id, user: auth.sub }).populate({ path: 'questions', populate: { path: 'tags' } })
-}
+const questionQuery = (parentValue, { id }, { auth }) => QuestionModel.findOne({ id, user: auth.sub })
 
 /* ----- mutations ----- */
-const createQuestionMutation = (parentValue, { question }, { auth }) => {
-  AuthService.isAuthenticated(auth)
-
-  return QuestionService.createQuestion({ ...question, userId: auth.sub })
-}
+const createQuestionMutation = (parentValue, { question }, { auth }) => QuestionService.createQuestion({ ...question, userId: auth.sub })
 
 module.exports = {
   allQuestions: allQuestionsQuery,

--- a/src/resolvers/questions.js
+++ b/src/resolvers/questions.js
@@ -1,5 +1,5 @@
 const QuestionService = require('../services/questions')
-const { QuestionModel, UserModel } = require('../models')
+const { QuestionModel, QuestionInstanceModel, UserModel } = require('../models')
 
 /* ----- queries ----- */
 const allQuestionsQuery = async (parentValue, args, { auth }) => {
@@ -8,8 +8,11 @@ const allQuestionsQuery = async (parentValue, args, { auth }) => {
 }
 
 const questionQuery = (parentValue, { id }) => QuestionModel.findById(id)
-const questionsQuery = (parentValue, args, context) =>
-  parentValue.questions.map(id => questionQuery(parentValue, { id }, context))
+const questionsQuery = parentValue => parentValue.questions.map(id => questionQuery(parentValue, { id }))
+
+const questionInstanceQuery = (parentValue, { id }) => QuestionInstanceModel.findById(id)
+const questionInstancesQuery = parentValue =>
+  parentValue.instances.map(id => questionInstanceQuery(parentValue, { id }))
 
 /* ----- mutations ----- */
 const createQuestionMutation = (parentValue, { question }, { auth }) =>
@@ -20,4 +23,6 @@ module.exports = {
   createQuestion: createQuestionMutation,
   question: questionQuery,
   questions: questionsQuery,
+  questionInstance: questionInstanceQuery,
+  questionInstances: questionInstancesQuery,
 }

--- a/src/resolvers/questions.js
+++ b/src/resolvers/questions.js
@@ -7,22 +7,27 @@ const allQuestionsQuery = async (parentValue, args, { auth }) => {
   return user.questions
 }
 
-const questionQuery = (parentValue, { id }) => QuestionModel.findById(id)
-const questionsQuery = parentValue => parentValue.questions.map(id => questionQuery(parentValue, { id }))
+const questionByIDQuery = (parentValue, { id }) => QuestionModel.findById(id)
+const questionByPVQuery = parentValue => QuestionModel.findById(parentValue.question)
+const questionsByPVQuery = parentValue => parentValue.questions.map(id => questionByIDQuery(parentValue, { id }))
 
-const questionInstanceQuery = (parentValue, { id }) => QuestionInstanceModel.findById(id)
-const questionInstancesQuery = parentValue =>
-  parentValue.instances.map(id => questionInstanceQuery(parentValue, { id }))
+const questionInstanceByIDQuery = (parentValue, { id }) => QuestionInstanceModel.findById(id)
+const questionInstancesByPVQuery = parentValue =>
+  parentValue.instances.map(id => questionInstanceByIDQuery(parentValue, { id }))
 
 /* ----- mutations ----- */
 const createQuestionMutation = (parentValue, { question }, { auth }) =>
   QuestionService.createQuestion({ ...question, userId: auth.sub })
 
 module.exports = {
+  // queries
   allQuestions: allQuestionsQuery,
+  question: questionByIDQuery,
+  questionByPV: questionByPVQuery,
+  questionsByPV: questionsByPVQuery,
+  questionInstance: questionInstanceByIDQuery,
+  questionInstancesByPV: questionInstancesByPVQuery,
+
+  // mutations
   createQuestion: createQuestionMutation,
-  question: questionQuery,
-  questions: questionsQuery,
-  questionInstance: questionInstanceQuery,
-  questionInstances: questionInstancesQuery,
 }

--- a/src/resolvers/questions.js
+++ b/src/resolvers/questions.js
@@ -9,11 +9,10 @@ const allQuestionsQuery = async (parentValue, args, { auth }) => {
 
 const questionByIDQuery = (parentValue, { id }) => QuestionModel.findById(id)
 const questionByPVQuery = parentValue => QuestionModel.findById(parentValue.question)
-const questionsByPVQuery = parentValue => parentValue.questions.map(id => questionByIDQuery(parentValue, { id }))
+const questionsByPVQuery = parentValue => QuestionModel.find({ _id: { $in: parentValue.questions } })
 
 const questionInstanceByIDQuery = (parentValue, { id }) => QuestionInstanceModel.findById(id)
-const questionInstancesByPVQuery = parentValue =>
-  parentValue.instances.map(id => questionInstanceByIDQuery(parentValue, { id }))
+const questionInstancesByPVQuery = parentValue => QuestionInstanceModel.find({ _id: { $in: parentValue.instances } })
 
 /* ----- mutations ----- */
 const createQuestionMutation = (parentValue, { question }, { auth }) =>

--- a/src/resolvers/questions.js
+++ b/src/resolvers/questions.js
@@ -7,13 +7,17 @@ const allQuestionsQuery = async (parentValue, args, { auth }) => {
   return user.questions
 }
 
-const questionQuery = (parentValue, { id }, { auth }) => QuestionModel.findOne({ id, user: auth.sub })
+const questionQuery = (parentValue, { id }) => QuestionModel.findById(id)
+const questionsQuery = (parentValue, args, context) =>
+  parentValue.questions.map(id => questionQuery(parentValue, { id }, context))
 
 /* ----- mutations ----- */
-const createQuestionMutation = (parentValue, { question }, { auth }) => QuestionService.createQuestion({ ...question, userId: auth.sub })
+const createQuestionMutation = (parentValue, { question }, { auth }) =>
+  QuestionService.createQuestion({ ...question, userId: auth.sub })
 
 module.exports = {
   allQuestions: allQuestionsQuery,
   createQuestion: createQuestionMutation,
   question: questionQuery,
+  questions: questionsQuery,
 }

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -8,15 +8,14 @@ const allSessionsQuery = async (parentValue, args, { auth }) => {
 }
 
 const sessionQuery = (parentValue, { id }) => SessionModel.findById(id)
-const sessionsQuery = (parentValue, args, context) =>
-  parentValue.sessions.map(id => sessionQuery(parentValue, { id }, context))
+const sessionsQuery = parentValue => parentValue.sessions.map(id => sessionQuery(parentValue, { id }))
 
 /* ----- mutations ----- */
 const createSessionMutation = (parentValue, { session: { name, blocks } }, { auth }) =>
   SessionService.createSession({
     name,
     questionBlocks: blocks,
-    user: auth.sub,
+    userId: auth.sub,
   })
 
 const startSessionMutation = (parentValue, { id }, { auth }) => SessionService.startSession({ id, userId: auth.sub })

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -1,43 +1,24 @@
-const AuthService = require('../services/auth')
 const SessionService = require('../services/sessions')
 const { SessionModel, UserModel } = require('../models')
 
 /* ----- queries ----- */
 const allSessionsQuery = async (parentValue, args, { auth }) => {
-  AuthService.isAuthenticated(auth)
-
   const user = await UserModel.findById(auth.sub).populate(['sessions'])
   return user.sessions
 }
 
-const sessionQuery = async (parentValue, { id }, { auth }) => {
-  AuthService.isAuthenticated(auth)
-
-  return SessionModel.findOne({ id, user: auth.sub })
-}
+const sessionQuery = (parentValue, { id }, { auth }) => SessionModel.findOne({ id, user: auth.sub })
 
 /* ----- mutations ----- */
-const createSessionMutation = async (parentValue, { session: { name, blocks } }, { auth }) => {
-  AuthService.isAuthenticated(auth)
+const createSessionMutation = (parentValue, { session: { name, blocks } }, { auth }) => SessionService.createSession({
+  name,
+  questionBlocks: blocks,
+  user: auth.sub,
+})
 
-  return SessionService.createSession({
-    name,
-    questionBlocks: blocks,
-    user: auth.sub,
-  })
-}
+const startSessionMutation = (parentValue, { id }, { auth }) => SessionService.startSession({ id, userId: auth.sub })
 
-const startSessionMutation = async (parentValue, { id }, { auth }) => {
-  AuthService.isAuthenticated(auth)
-
-  return SessionService.startSession({ id, userId: auth.sub })
-}
-
-const endSessionMutation = async (parentValue, { id }, { auth }) => {
-  AuthService.isAuthenticated(auth)
-
-  return SessionService.endSession({ id, userId: auth.sub })
-}
+const endSessionMutation = (parentValue, { id }, { auth }) => SessionService.endSession({ id, userId: auth.sub })
 
 module.exports = {
   allSessions: allSessionsQuery,

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -8,7 +8,7 @@ const allSessionsQuery = async (parentValue, args, { auth }) => {
 }
 
 const sessionByIDQuery = (parentValue, { id }) => SessionModel.findById(id)
-const sessionsByPVQuery = parentValue => parentValue.sessions.map(id => sessionByIDQuery(parentValue, { id }))
+const sessionsByPVQuery = parentValue => SessionModel.find({ _id: { $in: parentValue.sessions } })
 
 /* ----- mutations ----- */
 const createSessionMutation = (parentValue, { session: { name, blocks } }, { auth }) =>

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -7,8 +7,8 @@ const allSessionsQuery = async (parentValue, args, { auth }) => {
   return user.sessions
 }
 
-const sessionQuery = (parentValue, { id }) => SessionModel.findById(id)
-const sessionsQuery = parentValue => parentValue.sessions.map(id => sessionQuery(parentValue, { id }))
+const sessionByIDQuery = (parentValue, { id }) => SessionModel.findById(id)
+const sessionsByPVQuery = parentValue => parentValue.sessions.map(id => sessionByIDQuery(parentValue, { id }))
 
 /* ----- mutations ----- */
 const createSessionMutation = (parentValue, { session: { name, blocks } }, { auth }) =>
@@ -23,10 +23,13 @@ const startSessionMutation = (parentValue, { id }, { auth }) => SessionService.s
 const endSessionMutation = (parentValue, { id }, { auth }) => SessionService.endSession({ id, userId: auth.sub })
 
 module.exports = {
+  // queries
   allSessions: allSessionsQuery,
+  session: sessionByIDQuery,
+  sessionsByPV: sessionsByPVQuery,
+
+  // mutations
   createSession: createSessionMutation,
   endSession: endSessionMutation,
-  session: sessionQuery,
-  sessions: sessionsQuery,
   startSession: startSessionMutation,
 }

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -7,14 +7,17 @@ const allSessionsQuery = async (parentValue, args, { auth }) => {
   return user.sessions
 }
 
-const sessionQuery = (parentValue, { id }, { auth }) => SessionModel.findOne({ id, user: auth.sub })
+const sessionQuery = (parentValue, { id }) => SessionModel.findById(id)
+const sessionsQuery = (parentValue, args, context) =>
+  parentValue.sessions.map(id => sessionQuery(parentValue, { id }, context))
 
 /* ----- mutations ----- */
-const createSessionMutation = (parentValue, { session: { name, blocks } }, { auth }) => SessionService.createSession({
-  name,
-  questionBlocks: blocks,
-  user: auth.sub,
-})
+const createSessionMutation = (parentValue, { session: { name, blocks } }, { auth }) =>
+  SessionService.createSession({
+    name,
+    questionBlocks: blocks,
+    user: auth.sub,
+  })
 
 const startSessionMutation = (parentValue, { id }, { auth }) => SessionService.startSession({ id, userId: auth.sub })
 
@@ -25,5 +28,6 @@ module.exports = {
   createSession: createSessionMutation,
   endSession: endSessionMutation,
   session: sessionQuery,
+  sessions: sessionsQuery,
   startSession: startSessionMutation,
 }

--- a/src/resolvers/tags.js
+++ b/src/resolvers/tags.js
@@ -6,7 +6,8 @@ const allTagsQuery = async (parentValue, args, { auth }) => {
   return user.tags
 }
 
-const tagQuery = (parentValue, { id }, { auth }) => TagModel.findOne({ id, user: auth.sub })
+const tagQuery = (parentValue, { id }) => TagModel.findById(id)
+const tagsQuery = (parentValue, args, context) => parentValue.tags.map(id => tagQuery(parentValue, { id }, context))
 
 /* ----- mutations ----- */
 const createTagMutation = async (parentValue, { tag: { name } }, { auth }) => {
@@ -32,4 +33,5 @@ module.exports = {
   allTags: allTagsQuery,
   createTag: createTagMutation,
   tag: tagQuery,
+  tags: tagsQuery,
 }

--- a/src/resolvers/tags.js
+++ b/src/resolvers/tags.js
@@ -7,8 +7,7 @@ const allTagsQuery = async (parentValue, args, { auth }) => {
 }
 
 const tagByIDQuery = (parentValue, { id }) => TagModel.findById(id)
-const tagsByPVQuery = (parentValue, args, context) =>
-  parentValue.tags.map(id => tagByIDQuery(parentValue, { id }, context))
+const tagsByPVQuery = parentValue => TagModel.find({ _id: { $in: parentValue.tags } })
 
 /* ----- mutations ----- */
 const createTagMutation = async (parentValue, { tag: { name } }, { auth }) => {

--- a/src/resolvers/tags.js
+++ b/src/resolvers/tags.js
@@ -6,8 +6,9 @@ const allTagsQuery = async (parentValue, args, { auth }) => {
   return user.tags
 }
 
-const tagQuery = (parentValue, { id }) => TagModel.findById(id)
-const tagsQuery = (parentValue, args, context) => parentValue.tags.map(id => tagQuery(parentValue, { id }, context))
+const tagByIDQuery = (parentValue, { id }) => TagModel.findById(id)
+const tagsByPVQuery = (parentValue, args, context) =>
+  parentValue.tags.map(id => tagByIDQuery(parentValue, { id }, context))
 
 /* ----- mutations ----- */
 const createTagMutation = async (parentValue, { tag: { name } }, { auth }) => {
@@ -30,8 +31,11 @@ const createTagMutation = async (parentValue, { tag: { name } }, { auth }) => {
 }
 
 module.exports = {
+  // queries
   allTags: allTagsQuery,
+  tag: tagByIDQuery,
+  tags: tagsByPVQuery,
+
+  // mutations
   createTag: createTagMutation,
-  tag: tagQuery,
-  tags: tagsQuery,
 }

--- a/src/resolvers/tags.js
+++ b/src/resolvers/tags.js
@@ -1,18 +1,15 @@
-const AuthService = require('../services/auth')
 const { TagModel, UserModel } = require('../models')
 
 /* ----- queries ----- */
 const allTagsQuery = async (parentValue, args, { auth }) => {
-  AuthService.isAuthenticated(auth)
-
   const user = await UserModel.findById(auth.sub).populate(['tags'])
   return user.tags
 }
 
+const tagQuery = (parentValue, { id }, { auth }) => TagModel.findOne({ id, user: auth.sub })
+
 /* ----- mutations ----- */
 const createTagMutation = async (parentValue, { tag: { name } }, { auth }) => {
-  AuthService.isAuthenticated(auth)
-
   const newTag = new TagModel({
     name,
     user: auth.sub,
@@ -34,4 +31,5 @@ const createTagMutation = async (parentValue, { tag: { name } }, { auth }) => {
 module.exports = {
   allTags: allTagsQuery,
   createTag: createTagMutation,
+  tag: tagQuery,
 }

--- a/src/resolvers/users.js
+++ b/src/resolvers/users.js
@@ -2,8 +2,8 @@ const AuthService = require('../services/auth')
 const { UserModel } = require('../models')
 
 /* ----- queries ----- */
-const authUserQuery = (parentValue, args, { auth }) => UserModel.findById(auth.sub)
-const userQuery = parentValue => UserModel.findById(parentValue.user)
+const authUserByIDQuery = (parentValue, args, { auth }) => UserModel.findById(auth.sub)
+const userByIDQuery = parentValue => UserModel.findById(parentValue.user)
 
 /* ----- mutations ----- */
 const createUserMutation = (parentValue, { user: { email, password, shortname } }) =>
@@ -12,8 +12,11 @@ const createUserMutation = (parentValue, { user: { email, password, shortname } 
 const loginMutation = (parentValue, { email, password }, { res }) => AuthService.login(res, email, password)
 
 module.exports = {
+  // queries
+  authUser: authUserByIDQuery,
+  user: userByIDQuery,
+
+  // mutations
   createUser: createUserMutation,
   login: loginMutation,
-  authUser: authUserQuery,
-  user: userQuery,
 }

--- a/src/resolvers/users.js
+++ b/src/resolvers/users.js
@@ -2,7 +2,8 @@ const AuthService = require('../services/auth')
 const { UserModel } = require('../models')
 
 /* ----- queries ----- */
-const userQuery = (parentValue, args, { auth }) => UserModel.findById(auth.sub)
+const authUserQuery = (parentValue, args, { auth }) => UserModel.findById(auth.sub)
+const userQuery = parentValue => UserModel.findById(parentValue.user)
 
 /* ----- mutations ----- */
 const createUserMutation = (parentValue, { user: { email, password, shortname } }) =>
@@ -13,5 +14,6 @@ const loginMutation = (parentValue, { email, password }, { res }) => AuthService
 module.exports = {
   createUser: createUserMutation,
   login: loginMutation,
+  authUser: authUserQuery,
   user: userQuery,
 }

--- a/src/resolvers/users.js
+++ b/src/resolvers/users.js
@@ -2,11 +2,7 @@ const AuthService = require('../services/auth')
 const { UserModel } = require('../models')
 
 /* ----- queries ----- */
-const userQuery = (parentValue, args, { auth }) => {
-  AuthService.isAuthenticated(auth)
-
-  return UserModel.findById(auth.sub).populate(['questions', 'sessions', 'tags'])
-}
+const userQuery = (parentValue, args, { auth }) => UserModel.findById(auth.sub)
 
 /* ----- mutations ----- */
 const createUserMutation = (parentValue, { user: { email, password, shortname } }) =>

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,10 +1,11 @@
 const { makeExecutableSchema } = require('graphql-tools')
 
+const { requireAuth } = require('./services/auth')
 const { allQuestions, createQuestion, question } = require('./resolvers/questions')
 const {
   allSessions, createSession, endSession, session, startSession,
 } = require('./resolvers/sessions')
-const { allTags, createTag } = require('./resolvers/tags')
+const { allTags, createTag, tag } = require('./resolvers/tags')
 const { createUser, login, user } = require('./resolvers/users')
 const { allTypes } = require('./types')
 
@@ -48,21 +49,30 @@ const typeDefs = [
 // everything imported from their respective modules in resolvers/
 const resolvers = {
   Query: {
-    allQuestions,
-    allSessions,
-    allTags,
-    question,
-    session,
-    user,
+    allQuestions: requireAuth(allQuestions),
+    allSessions: requireAuth(allSessions),
+    allTags: requireAuth(allTags),
+    question: requireAuth(question),
+    session: requireAuth(session),
+    tag: requireAuth(tag),
+    user: requireAuth(user),
   },
   Mutation: {
-    createQuestion,
-    createSession,
-    createTag,
+    createQuestion: requireAuth(createQuestion),
+    createSession: requireAuth(createSession),
+    createTag: requireAuth(createTag),
     createUser,
-    endSession,
+    endSession: requireAuth(endSession),
     login,
-    startSession,
+    startSession: requireAuth(startSession),
+  },
+  Question: {
+    tags: (parentValue, args, context) => parentValue.tags.map(id => tag(parentValue, { id }, context)),
+  },
+  User: {
+    questions: (parentValue, args, context) => parentValue.questions.map(id => question(parentValue, { id }, context)),
+    sessions: (parentValue, args, context) => parentValue.sessions.map(id => session(parentValue, { id }, context)),
+    tags: (parentValue, args, context) => parentValue.tags.map(id => tag(parentValue, { id }, context)),
   },
 }
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,12 +1,14 @@
 const { makeExecutableSchema } = require('graphql-tools')
 
 const { requireAuth } = require('./services/auth')
-const { allQuestions, createQuestion, question } = require('./resolvers/questions')
+const { allQuestions, createQuestion, questions } = require('./resolvers/questions')
 const {
-  allSessions, createSession, endSession, session, startSession,
+  allSessions, createSession, endSession, sessions, startSession,
 } = require('./resolvers/sessions')
-const { allTags, createTag, tag } = require('./resolvers/tags')
-const { createUser, login, user } = require('./resolvers/users')
+const { allTags, createTag, tags } = require('./resolvers/tags')
+const {
+  createUser, login, user, authUser,
+} = require('./resolvers/users')
 const { allTypes } = require('./types')
 
 // create graphql schema in schema language
@@ -23,9 +25,6 @@ const typeDefs = [
     allQuestions: [Question]
     allSessions: [Session]
     allTags: [Tag]
-    question(id: ID): Question
-    session(id: ID): Session
-    tag(id: ID): Tag
     user: User
   }
 
@@ -52,10 +51,7 @@ const resolvers = {
     allQuestions: requireAuth(allQuestions),
     allSessions: requireAuth(allSessions),
     allTags: requireAuth(allTags),
-    question: requireAuth(question),
-    session: requireAuth(session),
-    tag: requireAuth(tag),
-    user: requireAuth(user),
+    user: requireAuth(authUser),
   },
   Mutation: {
     createQuestion: requireAuth(createQuestion),
@@ -67,12 +63,20 @@ const resolvers = {
     startSession: requireAuth(startSession),
   },
   Question: {
-    tags: (parentValue, args, context) => parentValue.tags.map(id => tag(parentValue, { id }, context)),
+    tags,
+    user,
+  },
+  Session: {
+    user,
+  },
+  Tag: {
+    questions,
+    user,
   },
   User: {
-    questions: (parentValue, args, context) => parentValue.questions.map(id => question(parentValue, { id }, context)),
-    sessions: (parentValue, args, context) => parentValue.sessions.map(id => session(parentValue, { id }, context)),
-    tags: (parentValue, args, context) => parentValue.tags.map(id => tag(parentValue, { id }, context)),
+    questions,
+    sessions,
+    tags,
   },
 }
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,7 +1,9 @@
 const { makeExecutableSchema } = require('graphql-tools')
 
 const { requireAuth } = require('./services/auth')
-const { allQuestions, createQuestion, questions } = require('./resolvers/questions')
+const {
+  allQuestions, createQuestion, questions, question, questionInstances,
+} = require('./resolvers/questions')
 const {
   allSessions, createSession, endSession, sessions, startSession,
 } = require('./resolvers/sessions')
@@ -65,6 +67,12 @@ const resolvers = {
   Question: {
     tags,
     user,
+  },
+  QuestionBlock: {
+    instances: questionInstances,
+  },
+  QuestionInstance: {
+    question,
   },
   Session: {
     user,

--- a/src/schema.js
+++ b/src/schema.js
@@ -2,10 +2,14 @@ const { makeExecutableSchema } = require('graphql-tools')
 
 const { requireAuth } = require('./services/auth')
 const {
-  allQuestions, createQuestion, questions, question, questionInstances,
+  allQuestions,
+  createQuestion,
+  questionsByPV,
+  questionByPV,
+  questionInstancesByPV,
 } = require('./resolvers/questions')
 const {
-  allSessions, createSession, endSession, sessions, startSession,
+  allSessions, createSession, endSession, sessionsByPV, startSession,
 } = require('./resolvers/sessions')
 const { allTags, createTag, tags } = require('./resolvers/tags')
 const {
@@ -69,21 +73,21 @@ const resolvers = {
     user,
   },
   QuestionBlock: {
-    instances: questionInstances,
+    instances: questionInstancesByPV,
   },
   QuestionInstance: {
-    question,
+    question: questionByPV,
   },
   Session: {
     user,
   },
   Tag: {
-    questions,
+    questions: questionsByPV,
     user,
   },
   User: {
-    questions,
-    sessions,
+    questions: questionsByPV,
+    sessions: sessionsByPV,
     tags,
   },
 }

--- a/src/server.js
+++ b/src/server.js
@@ -56,17 +56,14 @@ const server = express()
 // parse JWT that are passed as a header and attach their content to req.user
 server.use(
   '/graphql',
-
   // setup CORS
   cors({
     credentials: dev, // allow passing credentials over CORS in dev mode
     origin: 'http://localhost:3000',
     optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
   }),
-
   // enable cookie parsing
   cookieParser(),
-
   // setup JWT authentication
   expressJWT({
     credentialsRequired: false,
@@ -74,13 +71,10 @@ server.use(
     secret: process.env.APP_SECRET,
     getToken: AuthService.getToken,
   }),
-
   // parse json contents
   bodyParser.json(),
-
   // setup Apollo Optics if enabled
   withOptics ? opticsAgent.middleware() : f => f,
-
   // delegate to the GraphQL API
   graphqlExpress((req, res) => ({ context: { auth: req.auth, res, opticsContext: opticsAgent.context(req) }, schema })),
 )

--- a/src/server.js
+++ b/src/server.js
@@ -10,14 +10,14 @@ const opticsAgent = require('optics-agent')
 const { graphqlExpress } = require('apollo-server-express')
 
 const schema = require('./schema')
-const { isValidJWT } = require('./services/auth')
+const AuthService = require('./services/auth')
 
 mongoose.Promise = Promise
 
-opticsAgent.instrumentSchema(schema)
-
 const dev = process.env.NODE_ENV !== 'production'
 
+// require important environment variables to be present
+// otherwise exit the application
 const appSettings = ['APP_DOMAIN', 'APP_PORT', 'APP_SECRET', 'MONGO_URL']
 appSettings.forEach((envVar) => {
   if (!process.env[envVar]) {
@@ -35,6 +35,12 @@ if (process.env.MONGO_USER && process.env.MONGO_PASSWORD) {
   mongoose.connect(`mongodb://${process.env.MONGO_URL}`)
 }
 
+// setup Apollo Optics (GraphQL API metrics)
+const withOptics = !!process.env.OPTICS_API_KEY
+if (withOptics) {
+  opticsAgent.instrumentSchema(schema)
+}
+
 mongoose.connection
   .once('open', () => {
     console.log('> Connection to MongoDB established.')
@@ -50,37 +56,32 @@ const server = express()
 // parse JWT that are passed as a header and attach their content to req.user
 server.use(
   '/graphql',
+
+  // setup CORS
   cors({
     credentials: dev, // allow passing credentials over CORS in dev mode
     origin: 'http://localhost:3000',
     optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
   }),
+
+  // enable cookie parsing
   cookieParser(),
+
+  // setup JWT authentication
   expressJWT({
     credentialsRequired: false,
     requestProperty: 'auth',
     secret: process.env.APP_SECRET,
-    getToken: (req) => {
-      // try to parse an authorization cookie
-      if (req.cookies && req.cookies.jwt && isValidJWT(req.cookies.jwt, process.env.APP_SECRET)) {
-        return req.cookies.jwt
-      }
-
-      // try to parse the authorization header
-      if (
-        req.headers.authorization &&
-        req.headers.authorization.split(' ')[0] === 'Bearer' &&
-        isValidJWT(req.headers.authorization)
-      ) {
-        return req.headers.authorization.split(' ')[1]
-      }
-
-      // no token found
-      return null
-    },
+    getToken: AuthService.getToken,
   }),
+
+  // parse json contents
   bodyParser.json(),
-  opticsAgent.middleware(),
+
+  // setup Apollo Optics if enabled
+  withOptics ? opticsAgent.middleware() : f => f,
+
+  // delegate to the GraphQL API
   graphqlExpress((req, res) => ({ context: { auth: req.auth, res, opticsContext: opticsAgent.context(req) }, schema })),
 )
 

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -32,6 +32,26 @@ const isValidJWT = (jwt, secret) => {
   }
 }
 
+// extract JWT from header or cookie
+const getToken = (req) => {
+  // try to parse an authorization cookie
+  if (req.cookies && req.cookies.jwt && isValidJWT(req.cookies.jwt, process.env.APP_SECRET)) {
+    return req.cookies.jwt
+  }
+
+  // try to parse the authorization header
+  if (req.headers.authorization) {
+    const split = req.headers.authorization.split(' ')
+
+    if (split[0] === 'Bearer' && isValidJWT(split[1], process.env.APP_SECRET)) {
+      return split[1]
+    }
+  }
+
+  // no token found
+  return null
+}
+
 // signup a new user
 // make this an async function such that it returns a promise
 // we can later use this promise as a return value for resolvers or similar
@@ -99,6 +119,7 @@ module.exports = {
   isAuthenticated,
   requireAuth,
   isValidJWT,
+  getToken,
   signup,
   login,
 }

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -7,9 +7,19 @@ const dev = process.env.NODE_ENV !== 'production'
 
 // check whether an authentication object is valid
 const isAuthenticated = (auth) => {
-  if (!auth || !auth.sub) {
+  if (auth && auth.sub) {
+    return true
+  }
+  return false
+}
+
+// HOC to ensure the requester is authenticated
+// wraps a graphql resolver
+const requireAuth = wrapped => (parentValue, args, context) => {
+  if (!isAuthenticated(context.auth)) {
     throw new Error('INVALID_LOGIN')
   }
+  return wrapped(parentValue, args, context)
 }
 
 // check whether a JWT is valid
@@ -87,6 +97,7 @@ const login = async (res, email, password) => {
 
 module.exports = {
   isAuthenticated,
+  requireAuth,
   isValidJWT,
   signup,
   login,

--- a/src/services/auth.test.js
+++ b/src/services/auth.test.js
@@ -5,7 +5,7 @@ mongoose.Promise = Promise
 process.env.APP_SECRET = 'hello-world'
 
 const {
-  isAuthenticated, isValidJWT, signup, login,
+  isAuthenticated, isValidJWT, signup, login, requireAuth,
 } = require('./auth')
 const { UserModel } = require('../models')
 
@@ -24,10 +24,26 @@ describe('AuthService', () => {
       const auth3 = { sub: null }
       const auth4 = { sub: 'abcd' }
 
-      expect(() => isAuthenticated(auth1)).toThrow('INVALID_LOGIN')
-      expect(() => isAuthenticated(auth2)).toThrow('INVALID_LOGIN')
-      expect(() => isAuthenticated(auth3)).toThrow('INVALID_LOGIN')
-      expect(isAuthenticated(auth4)).toBeUndefined()
+      expect(isAuthenticated(auth1)).toEqual(false)
+      expect(isAuthenticated(auth2)).toEqual(false)
+      expect(isAuthenticated(auth3)).toEqual(false)
+      expect(isAuthenticated(auth4)).toEqual(true)
+    })
+  })
+
+  describe('requireAuth', () => {
+    it('restricts access to authenticated users', () => {
+      const auth1 = null
+      const auth2 = {}
+      const auth3 = { sub: null }
+      const auth4 = { sub: 'abcd' }
+
+      const wrappedFunction = requireAuth(() => 'something')
+
+      expect(() => wrappedFunction(null, null, { auth: auth1 })).toThrow('INVALID_LOGIN')
+      expect(() => wrappedFunction(null, null, { auth: auth2 })).toThrow('INVALID_LOGIN')
+      expect(() => wrappedFunction(null, null, { auth: auth3 })).toThrow('INVALID_LOGIN')
+      expect(wrappedFunction(null, null, { auth: auth4 })).toEqual('something')
     })
   })
 

--- a/src/services/sessions.js
+++ b/src/services/sessions.js
@@ -14,7 +14,7 @@ const createSession = async ({ name, questionBlocks, userId }) => {
   // skip any blocks that are empty (erroneous blocks)
   // create question instances for all questions within
   const blocks = questionBlocks.filter(block => block.questions.length > 0).map(block => ({
-    questions: block.questions.map((question) => {
+    instances: block.questions.map((question) => {
       // create a new question instance model
       const instance = new QuestionInstanceModel({
         question: question.id,

--- a/src/types/Question.js
+++ b/src/types/Question.js
@@ -24,6 +24,7 @@ const Question = `
 
     title: String!
     type: String!
+    user: User!
 
     instances: [QuestionInstance]
     tags: [Tag]

--- a/src/types/Session.js
+++ b/src/types/Session.js
@@ -42,6 +42,7 @@ const Session = `
     name: String!
     status: Int!
     settings: SessionSettings
+    user: User!
 
     blocks: [QuestionBlock]
     feedbacks: [Feedback]

--- a/src/types/Session.js
+++ b/src/types/Session.js
@@ -33,7 +33,7 @@ const Session = `
   }
 
   type QuestionBlock {
-    questions: [QuestionInstance]
+    instances: [QuestionInstance]
   }
 
   type Session {

--- a/src/types/Tag.js
+++ b/src/types/Tag.js
@@ -15,6 +15,7 @@ const Tag = `
     id: ID!
 
     name: String!
+    user: User!
 
     questions: [Question]!
 


### PR DESCRIPTION
Resolvers previously relied on MongoDB populate statements for nested fields/lists. One should use separate resolvers and dataloaders for this.

**General**
- Improve resolver structure to facilitate deeply nested queries
  - Resolve / "find" based on parentValues
  - Add field resolvers for each main model (like `Question`, ...)
  - Renaming and restructuring

**Misc**
- MongoDB: make the reference to possessing user required in all models
- Setup apollo optics if configured
- Extract `getToken` into AuthService
- Improve tests for `AuthService`

**Dependencies**