### PR TITLE
Update student mutations for string returns

### DIFF
--- a/src/integration/__snapshots__/integration.test.js.snap
+++ b/src/integration/__snapshots__/integration.test.js.snap
@@ -265,40 +265,15 @@ exports[`Integration Session Creation works 1`] = `
 `;
 
 exports[`Integration Session Execution allows adding confusion timesteps 1`] = `
-
-    addConfusionTS {
-      confusionTS: 
-        difficulty: 2
-        speed: 4
-      ,
-        difficulty: -2
-        speed: 3
-      ,
-        difficulty: -5
-        speed: 3
-      ,
-        difficulty: 5
-        speed: 2
-      
-    }
-  
+Object {
+  "addConfusionTS": "CONFUSION_ADDED",
+}
 `;
 
 exports[`Integration Session Execution allows adding feedbacks 1`] = `
-
-    addFeedback {
-      feedbacks: 
-        content: my test feedback
-        votes: 0
-      ,
-        content: good lecture
-        votes: 0
-      ,
-        content: my test feedback
-        votes: 0
-      
-    }
-  
+Object {
+  "addFeedback": "FEEDBACK_ADDED",
+}
 `;
 
 exports[`Integration Session Execution allows completing sessions 1`] = `

--- a/src/integration/mutations.js
+++ b/src/integration/mutations.js
@@ -269,27 +269,9 @@ const StartAndEndSessionSerializer = {
 
 const AddFeedbackMutation = `
   mutation AddFeedback($fp: ID, $sessionId: ID!, $content: String!) {
-    addFeedback(fp: $fp, sessionId: $sessionId, content: $content) {
-      id
-      feedbacks {
-        id
-        content
-        votes
-      }
-    }
+    addFeedback(fp: $fp, sessionId: $sessionId, content: $content)
   }
 `
-const AddFeedbackSerializer = {
-  test: ({ addFeedback }) => !!addFeedback,
-  print: ({ addFeedback: { feedbacks } }) => `
-    addFeedback {
-      feedbacks: ${feedbacks.map(({ content, votes }) => `
-        content: ${content}
-        votes: ${votes}
-      `)}
-    }
-  `,
-}
 
 const DeleteFeedbackMutation = `
   mutation DeleteFeedback($sessionId: ID!, $feedbackId: ID!) {
@@ -306,27 +288,9 @@ const DeleteFeedbackMutation = `
 
 const AddConfusionTSMutation = `
   mutation AddConfusionTS($fp: ID, $sessionId: ID!, $difficulty: Int!, $speed: Int!) {
-    addConfusionTS(fp: $fp, sessionId: $sessionId, difficulty: $difficulty, speed: $speed) {
-      id
-      confusionTS {
-        difficulty
-        speed
-        createdAt
-      }
-    }
+    addConfusionTS(fp: $fp, sessionId: $sessionId, difficulty: $difficulty, speed: $speed)
   }
 `
-const AddConfusionTSSerializer = {
-  test: ({ addConfusionTS }) => !!addConfusionTS,
-  print: ({ addConfusionTS: { confusionTS } }) => `
-    addConfusionTS {
-      confusionTS: ${confusionTS.map(({ difficulty, speed }) => `
-        difficulty: ${difficulty}
-        speed: ${speed}
-      `)}
-    }
-  `,
-}
 
 const UpdateSessionSettingsMutation = `
   mutation UpdateSessionSettings($sessionId: ID!, $settings: Session_SettingsInput!) {
@@ -351,9 +315,7 @@ const UpdateSessionSettingsSerializer = {
 
 const AddResponseMutation = `
   mutation AddResponse($fp: ID, $instanceId: ID!, $response: QuestionInstance_ResponseInput!) {
-    addResponse(fp: $fp, instanceId: $instanceId, response: $response) {
-      id
-    }
+    addResponse(fp: $fp, instanceId: $instanceId, response: $response)
   }
 `
 
@@ -430,8 +392,6 @@ module.exports = {
     CreateQuestionSerializer,
     CreateSessionSerializer,
     StartAndEndSessionSerializer,
-    AddFeedbackSerializer,
-    AddConfusionTSSerializer,
     UpdateSessionSettingsSerializer,
     ActivateNextBlockSerializer,
     ChangePasswordSerializer,

--- a/src/resolvers/questionInstances.js
+++ b/src/resolvers/questionInstances.js
@@ -27,13 +27,16 @@ const resultsByPVQuery = ({ results }) => {
 }
 
 /* ----- mutations ----- */
-const addResponseMutation = (parentValue, { fp, instanceId, response }, { ip }) =>
-  SessionExecService.addResponse({
+const addResponseMutation = async (parentValue, { fp, instanceId, response }, { ip }) => {
+  await SessionExecService.addResponse({
     fp,
     ip,
     instanceId,
     response,
   })
+
+  return 'RESPONSE_ADDED'
+}
 
 module.exports = {
   // queries

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -65,27 +65,33 @@ const activateNextBlockMutation = (parentValue, args, { auth }) =>
 const endSessionMutation = (parentValue, { id }, { auth }) =>
   SessionMgrService.endSession({ id, userId: auth.sub, shortname: auth.shortname })
 
-const addFeedbackMutation = (parentValue, { fp, sessionId, content }, { ip }) =>
-  SessionExecService.addFeedback({
+const addFeedbackMutation = async (parentValue, { fp, sessionId, content }, { ip }) => {
+  await SessionExecService.addFeedback({
     fp,
     ip,
     sessionId,
     content,
   })
 
+  return 'FEEDBACK_ADDED'
+}
+
 const deleteFeedbackMutation = (parentValue, { sessionId, feedbackId }, { auth }) =>
   SessionExecService.deleteFeedback({ sessionId, feedbackId, userId: auth.sub })
 
-const addConfusionTSMutation = (parentValue, {
+const addConfusionTSMutation = async (parentValue, {
   fp, sessionId, difficulty, speed,
-}, { ip }) =>
-  SessionExecService.addConfusionTS({
+}, { ip }) => {
+  await SessionExecService.addConfusionTS({
     fp,
     ip,
     sessionId,
     difficulty,
     speed,
   })
+
+  return 'CONFUSION_ADDED'
+}
 
 const updateSessionSettingsMutation = (parentValue, { sessionId, settings }, { auth }) =>
   SessionMgrService.updateSettings({

--- a/src/schema.js
+++ b/src/schema.js
@@ -60,9 +60,9 @@ const typeDefs = [
 
   type Mutation {
     activateNextBlock: Session!
-    addConfusionTS(fp: ID, sessionId: ID!, difficulty: Int!, speed: Int!): Session!
-    addFeedback(fp: ID, sessionId: ID!, content: String!): Session!
-    addResponse(fp: ID, instanceId: ID!, response: QuestionInstance_ResponseInput!): QuestionInstance!
+    addConfusionTS(fp: ID, sessionId: ID!, difficulty: Int!, speed: Int!): String!
+    addFeedback(fp: ID, sessionId: ID!, content: String!): String!
+    addResponse(fp: ID, instanceId: ID!, response: QuestionInstance_ResponseInput!): String!
     changePassword(newPassword: String!): User!
     createQuestion(question: QuestionInput!): Question!
     createSession(session: SessionInput!): Session!


### PR DESCRIPTION
Actions performed by students should only return success strings. They might have leaked information before these changes (unpublished feedbacks etc.).