### PR TITLE
Pausing Sessions

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,31 +1,39 @@
-const QuestionTypes = {
+const QUESTION_TYPES = {
   SC: 'SC',
   MC: 'MC',
   FREE: 'FREE',
   FREE_RANGE: 'FREE_RANGE',
 }
 
-const QuestionGroups = {
-  CHOICES: [QuestionTypes.SC, QuestionTypes.MC],
-  FREE: [QuestionTypes.FREE, QuestionTypes.FREE_RANGE],
-  WITH_OPTIONS: [QuestionTypes.SC, QuestionTypes.MC, QuestionTypes.FREE_RANGE],
+const QUESTION_GROUPS = {
+  CHOICES: [QUESTION_TYPES.SC, QUESTION_TYPES.MC],
+  FREE: [QUESTION_TYPES.FREE, QUESTION_TYPES.FREE_RANGE],
+  WITH_OPTIONS: [QUESTION_TYPES.SC, QUESTION_TYPES.MC, QUESTION_TYPES.FREE_RANGE],
 }
 
-const QuestionBlockStatus = {
+const QUESTION_BLOCK_STATUS = {
   PLANNED: 'PLANNED',
   ACTIVE: 'ACTIVE',
   EXECUTED: 'EXECUTED',
 }
 
-const SessionStatus = {
+const SESSION_STATUS = {
   CREATED: 'CREATED',
   RUNNING: 'RUNNING',
+  PAUSED: 'PAUSED',
   COMPLETED: 'COMPLETED',
 }
 
+const SESSION_ACTIONS = {
+  START: 'START',
+  PAUSE: 'PAUSE',
+  STOP: 'STOP',
+}
+
 module.exports = {
-  QuestionTypes,
-  QuestionGroups,
-  QuestionBlockStatus,
-  SessionStatus,
+  QUESTION_TYPES,
+  QUESTION_GROUPS,
+  QUESTION_BLOCK_STATUS,
+  SESSION_STATUS,
+  SESSION_ACTIONS,
 }

--- a/src/integration/__snapshots__/integration.test.js.snap
+++ b/src/integration/__snapshots__/integration.test.js.snap
@@ -332,10 +332,10 @@ Object {
 
 exports[`Integration Session Execution allows completing sessions 1`] = `
 
-    startSession / endSession {
+    startSession / pauseSession / endSession {
       status: COMPLETED
     }
-  
+    
 `;
 
 exports[`Integration Session Execution allows evaluating sessions after completion 1`] = `
@@ -552,6 +552,14 @@ exports[`Integration Session Execution allows running the full session flow (res
       
     }
   
+`;
+
+exports[`Integration Session Execution allows running the full session flow (responding and evaluation) LECTURER: can continue the session 1`] = `
+
+    startSession / pauseSession / endSession {
+      status: RUNNING
+    }
+    
 `;
 
 exports[`Integration Session Execution allows running the full session flow (responding and evaluation) LECTURER: can evaluate the first question block 1`] = `
@@ -1346,6 +1354,14 @@ exports[`Integration Session Execution allows running the full session flow (res
   
 `;
 
+exports[`Integration Session Execution allows running the full session flow (responding and evaluation) LECTURER: can pause the session 1`] = `
+
+    startSession / pauseSession / endSession {
+      status: PAUSED
+    }
+    
+`;
+
 exports[`Integration Session Execution allows running the full session flow (responding and evaluation) PARTICIPANT: can join the session initially 1`] = `
 
     joinSession {
@@ -1441,10 +1457,10 @@ exports[`Integration Session Execution allows running the full session flow (res
 
 exports[`Integration Session Execution allows starting sessions 1`] = `
 
-    startSession / endSession {
+    startSession / pauseSession / endSession {
       status: RUNNING
     }
-  
+    
 `;
 
 exports[`Integration Session Execution allows updating session settings 1`] = `

--- a/src/integration/integration.test.js
+++ b/src/integration/integration.test.js
@@ -6,7 +6,7 @@ const { initializeDb } = require('../lib/test/setup')
 const { createContentState } = require('../lib/draft')
 const queries = require('./queries')
 const mutations = require('./mutations')
-const { QuestionTypes } = require('../constants')
+const { QUESTION_TYPES } = require('../constants')
 
 process.env.NODE_ENV = 'test'
 
@@ -106,7 +106,7 @@ describe('Integration', () => {
         authCookie,
       ))
 
-      questions[QuestionTypes.SC] = data.createQuestion.id
+      questions[QUESTION_TYPES.SC] = data.createQuestion.id
 
       expect(data).toMatchSnapshot()
     })
@@ -136,7 +136,7 @@ describe('Integration', () => {
         authCookie,
       ))
 
-      questions[QuestionTypes.MC] = data.createQuestion.id
+      questions[QUESTION_TYPES.MC] = data.createQuestion.id
 
       expect(data).toMatchSnapshot()
     })
@@ -159,7 +159,7 @@ describe('Integration', () => {
         authCookie,
       ))
 
-      questions[QuestionTypes.FREE] = data.createQuestion.id
+      questions[QUESTION_TYPES.FREE] = data.createQuestion.id
 
       expect(data).toMatchSnapshot()
     })
@@ -184,7 +184,7 @@ describe('Integration', () => {
         authCookie,
       ))
 
-      questions[QuestionTypes.FREE_RANGE] = data.createQuestion.id
+      questions[QUESTION_TYPES.FREE_RANGE] = data.createQuestion.id
 
       expect(data).toMatchSnapshot()
     })
@@ -394,14 +394,14 @@ describe('Integration', () => {
             blocks: [
               {
                 questions: [
-                  { question: questions[QuestionTypes.SC], version: 0 },
-                  { question: questions[QuestionTypes.MC], version: 0 },
+                  { question: questions[QUESTION_TYPES.SC], version: 0 },
+                  { question: questions[QUESTION_TYPES.MC], version: 0 },
                 ],
               },
-              { questions: [{ question: questions[QuestionTypes.FREE], version: 0 }] },
+              { questions: [{ question: questions[QUESTION_TYPES.FREE], version: 0 }] },
               {
                 questions: [
-                  { question: questions[QuestionTypes.FREE_RANGE], version: 0 },
+                  { question: questions[QUESTION_TYPES.FREE_RANGE], version: 0 },
                   { question: questions.FREE_RANGE_PART, version: 0 },
                   { question: questions.FREE_RANGE_OPEN, version: 0 },
                 ],
@@ -596,6 +596,30 @@ describe('Integration', () => {
           authCookie,
         ))
         expect(evaluateSession).toMatchSnapshot()
+      })
+
+      it('LECTURER: can pause the session', async () => {
+        const data = ensureNoErrors(await sendQuery(
+          {
+            query: mutations.PauseSessionMutation,
+            variables: { id: sessionId },
+          },
+          authCookie,
+        ))
+
+        expect(data).toMatchSnapshot()
+      })
+
+      it('LECTURER: can continue the session', async () => {
+        const data = ensureNoErrors(await sendQuery(
+          {
+            query: mutations.StartSessionMutation,
+            variables: { id: sessionId },
+          },
+          authCookie,
+        ))
+
+        expect(data).toMatchSnapshot()
       })
 
       it('LECTURER: can close the first question block', async () => {

--- a/src/integration/mutations.js
+++ b/src/integration/mutations.js
@@ -272,6 +272,15 @@ const StartSessionMutation = `
     }
   }
 `
+
+const PauseSessionMutation = `
+  mutation PauseSession($id: ID!) {
+    pauseSession(id: $id) {
+      id
+      status
+    }
+  }
+`
 const EndSessionMutation = `
   mutation EndSession($id: ID!) {
     endSession(id: $id) {
@@ -281,12 +290,19 @@ const EndSessionMutation = `
   }
 `
 const StartAndEndSessionSerializer = {
-  test: ({ endSession, startSession }) => endSession || startSession,
-  print: ({ endSession, startSession }) => `
-    startSession / endSession {
-      status: ${endSession ? endSession.status : startSession.status}
+  test: ({ endSession, startSession, pauseSession }) => endSession || startSession || pauseSession,
+  print: ({ endSession, startSession, pauseSession }) => {
+    const status =
+      (endSession && endSession.status) ||
+      (startSession && startSession.status) ||
+      (pauseSession && pauseSession.status)
+
+    return `
+    startSession / pauseSession / endSession {
+      status: ${status}
     }
-  `,
+    `
+  },
 }
 
 const AddFeedbackMutation = `
@@ -400,6 +416,7 @@ module.exports = {
   ModifyQuestionMutation,
   CreateSessionMutation,
   StartSessionMutation,
+  PauseSessionMutation,
   EndSessionMutation,
   AddFeedbackMutation,
   DeleteFeedbackMutation,

--- a/src/lib/test/setup.js
+++ b/src/lib/test/setup.js
@@ -5,7 +5,7 @@ const AuthService = require('../../services/auth')
 const QuestionService = require('../../services/questions')
 const { createContentState } = require('../../lib/draft')
 
-const { QuestionTypes } = require('../../constants')
+const { QUESTION_TYPES } = require('../../constants')
 
 const setupTestEnv = async ({ email, password, shortname }) => {
   // find the id of the user to reset
@@ -69,7 +69,7 @@ const initializeDb = async ({
 
     if (withQuestions) {
       result.questions = {
-        [QuestionTypes.SC]: await QuestionService.createQuestion({
+        [QUESTION_TYPES.SC]: await QuestionService.createQuestion({
           content: createContentState('very good'),
           options: {
             choices: [
@@ -81,10 +81,10 @@ const initializeDb = async ({
           },
           tags: ['CDEF'],
           title: 'second question',
-          type: QuestionTypes.SC,
+          type: QUESTION_TYPES.SC,
           userId: result.userId,
         }),
-        [QuestionTypes.MC]: await QuestionService.createQuestion({
+        [QUESTION_TYPES.MC]: await QuestionService.createQuestion({
           content: createContentState('very good'),
           options: {
             choices: [
@@ -96,18 +96,18 @@ const initializeDb = async ({
           },
           tags: ['CDEF'],
           title: 'second question',
-          type: QuestionTypes.MC,
+          type: QUESTION_TYPES.MC,
           userId: result.userId,
         }),
-        [QuestionTypes.FREE]: await QuestionService.createQuestion({
+        [QUESTION_TYPES.FREE]: await QuestionService.createQuestion({
           content: createContentState('a description'),
           options: {},
           tags: ['AZA', 'BBB'],
           title: 'first question',
-          type: QuestionTypes.FREE,
+          type: QUESTION_TYPES.FREE,
           userId: result.userId,
         }),
-        [QuestionTypes.FREE_RANGE]: await QuestionService.createQuestion({
+        [QUESTION_TYPES.FREE_RANGE]: await QuestionService.createQuestion({
           content: createContentState('a description'),
           options: {
             restrictions: {
@@ -117,7 +117,7 @@ const initializeDb = async ({
           },
           tags: ['AZA', 'BBB'],
           title: 'first question',
-          type: QuestionTypes.FREE_RANGE,
+          type: QUESTION_TYPES.FREE_RANGE,
           userId: result.userId,
         }),
         FREE_RANGE_PART: await QuestionService.createQuestion({
@@ -130,7 +130,7 @@ const initializeDb = async ({
           },
           tags: ['CDEF', 'BBB'],
           title: 'partly restricted free range',
-          type: QuestionTypes.FREE_RANGE,
+          type: QUESTION_TYPES.FREE_RANGE,
           userId: result.userId,
         }),
         FREE_RANGE_OPEN: await QuestionService.createQuestion({
@@ -143,7 +143,7 @@ const initializeDb = async ({
           },
           tags: ['CDEF', 'BBB'],
           title: 'unrestricted free range',
-          type: QuestionTypes.FREE_RANGE,
+          type: QUESTION_TYPES.FREE_RANGE,
           userId: result.userId,
         }),
       }

--- a/src/models/Question.js
+++ b/src/models/Question.js
@@ -3,14 +3,14 @@ const _values = require('lodash/values')
 
 const { ObjectId } = mongoose.Schema.Types
 
-const { QuestionTypes } = require('../constants')
+const { QUESTION_TYPES } = require('../constants')
 const QuestionVersion = require('./QuestionVersion')
 
 const Question = new mongoose.Schema({
   title: { type: String, required: true },
   type: {
     type: String,
-    enum: _values(QuestionTypes),
+    enum: _values(QUESTION_TYPES),
     required: true,
     index: true,
   },

--- a/src/models/QuestionBlock.js
+++ b/src/models/QuestionBlock.js
@@ -3,14 +3,14 @@ const _values = require('lodash/values')
 
 const { ObjectId } = mongoose.Schema.Types
 
-const { QuestionBlockStatus } = require('../constants')
+const { QUESTION_BLOCK_STATUS } = require('../constants')
 
 module.exports = {
   QuestionBlock: new mongoose.Schema({
     status: {
       type: String,
-      enum: _values(QuestionBlockStatus),
-      default: QuestionBlockStatus.PLANNED,
+      enum: _values(QUESTION_BLOCK_STATUS),
+      default: QUESTION_BLOCK_STATUS.PLANNED,
     },
     timeLimit: { type: Number, default: -1, min: -1 },
     showSolutions: { type: Boolean, default: false },

--- a/src/models/Session.js
+++ b/src/models/Session.js
@@ -6,14 +6,14 @@ const { ObjectId } = mongoose.Schema.Types
 const Feedback = require('./Feedback')
 const ConfusionTimestep = require('./ConfusionTimestep')
 const { QuestionBlock } = require('./QuestionBlock')
-const { SessionStatus } = require('../constants')
+const { SESSION_STATUS } = require('../constants')
 
 const Session = new mongoose.Schema({
   name: { type: String, default: Date.now(), index: true },
   status: {
     type: String,
-    enum: _values(SessionStatus),
-    default: SessionStatus.CREATED,
+    enum: _values(SESSION_STATUS),
+    default: SESSION_STATUS.CREATED,
     index: true,
   },
   settings: {

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -36,6 +36,7 @@ const User = new mongoose.Schema({
 
   runningSession: { type: ObjectId, ref: 'Session' },
 
+  lastLoginAt: { type: Date },
   createdAt: { type: Date, default: Date.now() },
   updatedAt: { type: Date, default: Date.now() },
 })

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,11 +1,11 @@
 const ConfusionTimestep = require('./ConfusionTimestep')
 const Feedback = require('./Feedback')
-const { QuestionModel, QuestionTypes } = require('./Question')
-const { QuestionBlock, QuestionBlockStatus } = require('./QuestionBlock')
-const { QuestionOptions, FREERestrictionTypes } = require('./QuestionOptions')
+const { QuestionModel } = require('./Question')
+const { QuestionBlock } = require('./QuestionBlock')
+const { QuestionOptions } = require('./QuestionOptions')
 const QuestionVersion = require('./QuestionVersion')
 const QuestionInstanceModel = require('./QuestionInstance')
-const { SessionModel, SessionStatus } = require('./Session')
+const { SessionModel } = require('./Session')
 const TagModel = require('./Tag')
 const UserModel = require('./User')
 
@@ -13,15 +13,11 @@ module.exports = {
   ConfusionTimestep,
   Feedback,
   QuestionModel,
-  QuestionTypes,
   QuestionBlock,
-  QuestionBlockStatus,
   QuestionInstanceModel,
   QuestionOptions,
-  FREERestrictionTypes,
   QuestionVersion,
   SessionModel,
-  SessionStatus,
   TagModel,
   UserModel,
 }

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -64,6 +64,9 @@ const startSessionMutation = (parentValue, { id }, { auth }) =>
 const activateNextBlockMutation = (parentValue, args, { auth }) =>
   SessionMgrService.activateNextBlock({ userId: auth.sub, shortname: auth.shortname })
 
+const pauseSessionMutation = (parentValue, { id }, { auth }) =>
+  SessionMgrService.pauseSession({ id, userId: auth.sub, shortname: auth.shrotname })
+
 const endSessionMutation = (parentValue, { id }, { auth }) =>
   SessionMgrService.endSession({ id, userId: auth.sub, shortname: auth.shortname })
 
@@ -117,6 +120,7 @@ module.exports = {
   createSession: createSessionMutation,
   endSession: endSessionMutation,
   activateNextBlock: activateNextBlockMutation,
+  pauseSession: pauseSessionMutation,
   startSession: startSessionMutation,
   addFeedback: addFeedbackMutation,
   deleteFeedback: deleteFeedbackMutation,

--- a/src/schema.js
+++ b/src/schema.js
@@ -18,6 +18,7 @@ const {
   addConfusionTS,
   allSessions,
   createSession,
+  pauseSession,
   endSession,
   joinSession,
   runningSession,
@@ -75,6 +76,7 @@ const typeDefs = [
     login(email: String!, password: String!): ID!
     logout: String!
     modifyQuestion(id: ID!, question: QuestionModifyInput!): Question!
+    pauseSession(id: ID!): Session!
     requestPassword(email: String!): String!
     startSession(id: ID!): Session!
     updateSessionSettings(sessionId: ID!, settings: Session_SettingsInput!): Session!
@@ -116,6 +118,7 @@ const resolvers = {
     login,
     logout,
     modifyQuestion: requireAuth(modifyQuestion),
+    pauseSession: requireAuth(pauseSession),
     requestPassword,
     startSession: requireAuth(startSession),
     updateSessionSettings: requireAuth(updateSessionSettings),

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -147,6 +147,14 @@ const login = async (res, email, password) => {
     })
   }
 
+  // update the last login date
+  await UserModel.findOneAndUpdate(
+    { email },
+    {
+      $currentDate: { lastLoginAt: true, updatedAt: true },
+    },
+  )
+
   // resolve with data about the user
   return user.id
 }

--- a/src/services/questions.js
+++ b/src/services/questions.js
@@ -3,7 +3,7 @@ const _isNumber = require('lodash/isNumber')
 const { ContentState, convertToRaw } = require('draft-js')
 
 const { QuestionModel, TagModel, UserModel } = require('../models')
-const { QuestionGroups, QuestionTypes } = require('../constants')
+const { QUESTION_GROUPS, QUESTION_TYPES } = require('../constants')
 const { convertToPlainText } = require('../lib/draft')
 
 // process tags when editing or creating a question
@@ -40,12 +40,12 @@ const createQuestion = async ({
   }
 
   // if no options have been assigned, throw
-  if (QuestionGroups.WITH_OPTIONS.includes(type) && !options) {
+  if (QUESTION_GROUPS.WITH_OPTIONS.includes(type) && !options) {
     throw new Error('NO_OPTIONS_SPECIFIED')
   }
 
   // validation for SC and MC questions
-  if (QuestionGroups.CHOICES.includes(type)) {
+  if (QUESTION_GROUPS.CHOICES.includes(type)) {
     if (options.choices.length === 0) {
       throw new Error('NO_CHOICES_SPECIFIED')
     }
@@ -56,7 +56,7 @@ const createQuestion = async ({
   }
 
   // validation for FREE_RANGE questions
-  if (type === QuestionTypes.FREE_RANGE) {
+  if (type === QUESTION_TYPES.FREE_RANGE) {
     if (!options.restrictions) {
       throw new Error('MISSING_RESTRICTIONS')
     }
@@ -92,7 +92,7 @@ const createQuestion = async ({
       {
         content,
         description: convertToPlainText(content),
-        options: QuestionGroups.WITH_OPTIONS.includes(type) && {
+        options: QUESTION_GROUPS.WITH_OPTIONS.includes(type) && {
           [type]: options,
         },
         solution,
@@ -139,7 +139,7 @@ const modifyQuestion = async (questionId, userId, {
   }
 
   if (
-    QuestionGroups.CHOICES.includes(question.type) &&
+    QUESTION_GROUPS.CHOICES.includes(question.type) &&
     solution &&
     options.choices.length !== solution[question.type].length
   ) {
@@ -212,10 +212,10 @@ const modifyQuestion = async (questionId, userId, {
     question.versions.push({
       content,
       description: convertToPlainText(content),
-      options: QuestionGroups.WITH_OPTIONS.includes(question.type) && {
+      options: QUESTION_GROUPS.WITH_OPTIONS.includes(question.type) && {
         // HACK: manually ensure randomized is default set to false
         // TODO: mongoose should do this..?
-        [question.type]: QuestionGroups.CHOICES.includes(question.type) ? { randomized: false, ...options } : options,
+        [question.type]: QUESTION_GROUPS.CHOICES.includes(question.type) ? { randomized: false, ...options } : options,
       },
       solution,
     })

--- a/src/services/sessionExec.js
+++ b/src/services/sessionExec.js
@@ -2,7 +2,7 @@ const md5 = require('md5')
 const _isNumber = require('lodash/isNumber')
 
 const { QuestionInstanceModel, UserModel } = require('../models')
-const { QuestionGroups, QuestionTypes } = require('../constants')
+const { QUESTION_GROUPS, QUESTION_TYPES } = require('../constants')
 const { getRedis } = require('../redis')
 const { getRunningSession } = require('./sessionMgr')
 const { pubsub, CONFUSION_ADDED, FEEDBACK_ADDED } = require('../resolvers/subscriptions')
@@ -162,14 +162,14 @@ const addResponse = async ({
   const currentVersion = instance.question.versions[instance.version]
 
   // result parsing for SC/MC questions
-  if (QuestionGroups.CHOICES.includes(questionType)) {
+  if (QUESTION_GROUPS.CHOICES.includes(questionType)) {
     // if the response doesn't contain any valid choices, throw
     if (!response.choices || !response.choices.length > 0) {
       throw new Error('INVALID_RESPONSE')
     }
 
     // if the response contains multiple choices for a SC question
-    if (questionType === QuestionTypes.SC && response.choices.length > 1) {
+    if (questionType === QUESTION_TYPES.SC && response.choices.length > 1) {
       throw new Error('TOO_MANY_CHOICES')
     }
 
@@ -187,12 +187,12 @@ const addResponse = async ({
     })
     instance.results.totalParticipants += 1
     instance.markModified('results.CHOICES')
-  } else if (QuestionGroups.FREE.includes(questionType)) {
+  } else if (QUESTION_GROUPS.FREE.includes(questionType)) {
     if (!response.value || response.value.length > 1000) {
       throw new Error('INVALID_RESPONSE')
     }
 
-    if (questionType === QuestionTypes.FREE_RANGE) {
+    if (questionType === QUESTION_TYPES.FREE_RANGE) {
       if (!_isNumber(response.value * 1)) {
         throw new Error('INVALID_RESPONSE')
       }

--- a/src/services/sessionExec.test.js
+++ b/src/services/sessionExec.test.js
@@ -8,7 +8,7 @@ const SessionExecService = require('./sessionExec')
 const { initializeDb, prepareSessionFactory } = require('../lib/test/setup')
 const { sessionSerializer, questionInstanceSerializer } = require('../lib/test/serializers')
 
-const { QuestionTypes } = require('../constants')
+const { QUESTION_TYPES } = require('../constants')
 
 mongoose.Promise = Promise
 
@@ -169,10 +169,10 @@ describe('SessionExecService', () => {
       preparedSession = await prepareSession(
         userId,
         [
-          { question: questions[QuestionTypes.SC].id, version: 0 },
-          { question: questions[QuestionTypes.MC].id, version: 0 },
-          { question: questions[QuestionTypes.FREE].id, version: 0 },
-          { question: questions[QuestionTypes.FREE_RANGE].id, version: 0 },
+          { question: questions[QUESTION_TYPES.SC].id, version: 0 },
+          { question: questions[QUESTION_TYPES.MC].id, version: 0 },
+          { question: questions[QUESTION_TYPES.FREE].id, version: 0 },
+          { question: questions[QUESTION_TYPES.FREE_RANGE].id, version: 0 },
         ],
         true,
       )

--- a/src/types/Session.js
+++ b/src/types/Session.js
@@ -9,6 +9,7 @@ const Session = `
   enum Session_Status {
     CREATED
     RUNNING
+    PAUSED
     COMPLETED
   }
 


### PR DESCRIPTION
Pausing sessions that are running and continuing them at a later time.

**GENERAL**
- Add `PauseSessionMutation` and necessary resolvers
- Add a new session status: `PAUSED`
- Implement `pauseSession` in session manager service
- Rework logic for `startSession`, `endSession` and `pauseSession` to build upon a single function (keep dry).

**MISC**
- Refactor constants to be all UPPERCASE
- Add update of `lastLoginAt` on a successful login
