### PR TITLE
Apollo Server 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Roland Schläfli <roland.schlaefli@bf.uzh.ch>",
   "license": "AGPL-3.0",
   "dependencies": {
-    "apollo-server-express": "1.3.6",
+    "apollo-server-express": "2.0.0-rc.2",
     "bcryptjs": "2.4.3",
     "bluebird": "3.5.1",
     "body-parser": "1.18.3",

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "assignees": ["rschlaefli"],
   "labels": ["dependencies"],
   "reviewers": ["rschlaefli"],
-  "schedule": ["after 9am and before 4pm on monday and wednesday"],
+  "schedule": ["after 7pm and before 8am on every weekday"],
   "semanticCommits": false,
   "timezone": "Europe/Zurich",
   "packageRules": [

--- a/src/app.js
+++ b/src/app.js
@@ -14,22 +14,24 @@ if (process.env.SENTRY_DSN) {
   Raven = require('raven')
 }
 
+// base packages
+const mongoose = require('mongoose')
+const express = require('express')
+const { ApolloServer } = require('apollo-server-express')
+mongoose.Promise = require('bluebird')
+
+// express middlewares
 const bodyParser = require('body-parser')
 const cors = require('cors')
 const cookieParser = require('cookie-parser')
-const express = require('express')
 const expressJWT = require('express-jwt')
-const mongoose = require('mongoose')
-mongoose.Promise = require('bluebird')
 const compression = require('compression')
 const helmet = require('helmet')
 const morgan = require('morgan')
 const RateLimit = require('express-rate-limit')
-const { graphqlExpress, graphiqlExpress } = require('apollo-server-express')
 
-const schema = require('./schema')
 const AuthService = require('./services/auth')
-// const queryMap = require('./queryMap.json')
+const { resolvers, typeDefs } = require('./schema')
 const { getRedis } = require('./redis')
 const { exceptTest } = require('./lib/utils')
 const { createLoaders } = require('./lib/loaders')
@@ -82,12 +84,12 @@ mongoose.connection
   })
 
 // initialize an express server
-const server = express()
+const app = express()
 
 // if the server is behind a proxy, set the APP_PROXY env to true
 // this will make express trust the X-* proxy headers and set corresponding req.ip
 if (process.env.APP_PROXY) {
-  server.enable('trust proxy')
+  app.enable('trust proxy')
 }
 
 // setup middleware stack
@@ -118,9 +120,13 @@ let middleware = [
   }),
 ]
 
+// add production middlewares
 if (isProd) {
-  // if a sentry dsn is set, configure raven
+  // add the morgan logging middleware in production
+  middleware.push(morgan('combined'))
+
   if (process.env.SENTRY_DSN) {
+    // if a sentry dsn is set, configure raven
     Raven.config(process.env.SENTRY_DSN).install()
     middleware = [
       Raven.requestHandler(),
@@ -131,76 +137,8 @@ if (isProd) {
   } else {
     middleware = [compression(), ...middleware]
   }
-}
 
-if (process.env.APP_RATE_LIMITING) {
-  // basic rate limiting configuration
-  const limiterSettings = {
-    windowMs: 5 * 60 * 1000, // in a 5 minute window
-    max: 1000, // limit to 200 requests
-    delayAfter: 200, // start delaying responses after 100 requests
-    delayMs: 50, // delay responses by 250ms * (numResponses - delayAfter)
-    keyGenerator: req => `${req.auth ? req.auth.sub : req.ip}`,
-    onLimitReached: req => exceptTest(() => {
-      const error = `> Rate-Limited a Request from ${req.ip} ${req.auth.sub
-          || 'anon'}!`
-
-      console.error(error)
-
-      if (apm) {
-        apm.captureError(error)
-      }
-
-      if (Raven) {
-        Raven.captureException(error)
-      }
-    }),
-  }
-
-  // if redis is available, use it to centrally store rate limiting dataconst
-  const redis = getRedis(1)
-  let limiter
-  if (redis) {
-    const RedisStore = require('rate-limit-redis')
-    limiter = new RateLimit({
-      ...limiterSettings,
-      store:
-        redis
-        && new RedisStore({
-          client: redis,
-          expiry: 5 * 60,
-          prefix: 'rl-api:',
-        }),
-    })
-  } else {
-    // if redis is not available, setup basic rate limiting with in-memory store
-    limiter = new RateLimit(limiterSettings)
-  }
-
-  middleware.push(limiter)
-}
-
-// add the query caching middleware
-/* middleware.push(async (req, res, next) => {
-  console.log(req)
-
-  const queryHash = _get(req.body, 'extensions.persistedQuery')
-  if (queryHash) {
-    const query = queryMap[queryHash.sha256Hash]
-    if (query) {
-      // req.body.query = query
-      console.log('query')
-    }
-  }
-
-  next()
-}) */
-
-if (isProd) {
-  // add the morgan logging middleware in production
-  middleware.push(morgan('combined'))
-
-  // add the persisted query middleware in production
+  // add an elastic APM middleware
   middleware.push((req, res, next) => {
     // set the APM transaction name
     if (apm) {
@@ -214,33 +152,76 @@ if (isProd) {
 
     next()
   })
+
+  // add a rate limiting middleware
+  if (process.env.APP_RATE_LIMITING) {
+    // basic rate limiting configuration
+    const limiterSettings = {
+      windowMs: 5 * 60 * 1000, // in a 5 minute window
+      max: 1000, // limit to 200 requests
+      delayAfter: 200, // start delaying responses after 100 requests
+      delayMs: 50, // delay responses by 250ms * (numResponses - delayAfter)
+      keyGenerator: req => `${req.auth ? req.auth.sub : req.ip}`,
+      onLimitReached: req => exceptTest(() => {
+        const error = `> Rate-Limited a Request from ${req.ip} ${req.auth
+          .sub || 'anon'}!`
+
+        console.error(error)
+
+        if (apm) {
+          apm.captureError(error)
+        }
+
+        if (Raven) {
+          Raven.captureException(error)
+        }
+      }),
+    }
+
+    // if redis is available, use it to centrally store rate limiting dataconst
+    const redis = getRedis(1)
+    let limiter
+    if (redis) {
+      const RedisStore = require('rate-limit-redis')
+      limiter = new RateLimit({
+        ...limiterSettings,
+        store:
+          redis
+          && new RedisStore({
+            client: redis,
+            expiry: 5 * 60,
+            prefix: 'rl-api:',
+          }),
+      })
+    } else {
+      // if redis is not available, setup basic rate limiting with in-memory store
+      limiter = new RateLimit(limiterSettings)
+    }
+
+    middleware.push(limiter)
+  }
 }
 
-// start up graphiql in development mode
-if (process.env.NODE_ENV === 'development') {
-  server.use(
-    '/graphiql',
-    graphiqlExpress({
-      endpointURL: '/graphql',
-      subscriptionsEndpoint: 'ws://localhost:4000/subscriptions',
-    }),
-  )
-}
+// inject the middleware into express
+app.use(middleware)
 
-// expose the GraphQL API endpoint
-// parse JWT that are passed as a header and attach their content to req.user
-server.use(
-  ...middleware,
-  // delegate to the GraphQL API
-  graphqlExpress((req, res) => ({
-    context: {
-      auth: req.auth,
-      ip: req.ip,
-      loaders: createLoaders(req.auth),
-      res,
-    },
-    schema,
-  })),
-)
+// setup a new apollo server instance
+const apollo = new ApolloServer({
+  typeDefs,
+  resolvers,
+  context: ({ req, res }) => ({
+    auth: req.auth,
+    ip: req.ip,
+    loaders: createLoaders(req.auth),
+    res,
+  }),
+})
 
-module.exports = server
+// apply the apollo middleware to express
+apollo.applyMiddleware({
+  app,
+  cors: false,
+  bodyParserConfig: false,
+})
+
+module.exports = { app, apollo }

--- a/src/app.js
+++ b/src/app.js
@@ -212,7 +212,6 @@ const apollo = new ApolloServer({
   context: async ({ connection, req, res }) => {
     // context handler for subscriptions
     if (connection) {
-      console.log(connection)
       return {}
     }
 

--- a/src/app.js
+++ b/src/app.js
@@ -209,12 +209,20 @@ app.use(middleware)
 const apollo = new ApolloServer({
   typeDefs,
   resolvers,
-  context: ({ req, res }) => ({
-    auth: req.auth,
-    ip: req.ip,
-    loaders: createLoaders(req.auth),
-    res,
-  }),
+  context: async ({ connection, req, res }) => {
+    // context handler for subscriptions
+    if (connection) {
+      return {}
+    }
+
+    // context handler for normal requests
+    return {
+      auth: req.auth,
+      ip: req.ip,
+      loaders: createLoaders(req.auth),
+      res,
+    }
+  },
 })
 
 // apply the apollo middleware to express

--- a/src/app.js
+++ b/src/app.js
@@ -212,6 +212,7 @@ const apollo = new ApolloServer({
   context: async ({ connection, req, res }) => {
     // context handler for subscriptions
     if (connection) {
+      console.log(connection)
       return {}
     }
 

--- a/src/integration/__snapshots__/integration.test.js.snap
+++ b/src/integration/__snapshots__/integration.test.js.snap
@@ -9,6 +9,9 @@ Object {
 exports[`Integration Logout works 2`] = `
 Array [
   Object {
+    "extensions": Object {
+      "code": "UNAUTHENTICATED",
+    },
     "locations": Array [
       Object {
         "column": 5,

--- a/src/integration/integration.test.js
+++ b/src/integration/integration.test.js
@@ -1,7 +1,7 @@
 const request = require('supertest')
 const mongoose = require('mongoose')
 
-const server = require('../app')
+const { app } = require('../app')
 const { initializeDb } = require('../lib/test/setup')
 const { createContentState } = require('../lib/draft')
 const queries = require('./queries')
@@ -15,13 +15,13 @@ serializers.forEach(serializer => expect.addSnapshotSerializer(serializer))
 
 const sendQuery = (body, authCookie) => {
   if (authCookie) {
-    return request(server)
+    return request(app)
       .post('/graphql')
       .set('Cookie', authCookie)
       .send(body)
   }
 
-  return request(server)
+  return request(app)
     .post('/graphql')
     .send(body)
 }
@@ -47,7 +47,7 @@ describe('Integration', () => {
 
   afterAll(async () => {
     await mongoose.disconnect()
-    await server.close()
+    await app.close()
     authCookie = null
   })
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,4 +1,3 @@
-const { makeExecutableSchema } = require('graphql-tools')
 const { requireAuth } = require('./services/auth')
 const {
   allQuestions,
@@ -196,7 +195,7 @@ const resolvers = {
 }
 
 // use graphql-tools to generate a usable schema for export
-module.exports = makeExecutableSchema({
+module.exports = {
   resolvers,
   typeDefs,
-})
+}

--- a/src/services/questions.js
+++ b/src/services/questions.js
@@ -1,6 +1,7 @@
 const _isNumber = require('lodash/isNumber')
 // TODO: find a way to use draft.js without needing react and react-dom
 const { ContentState, convertToRaw } = require('draft-js')
+const { UserInputError } = require('apollo-server-express')
 
 const { QuestionModel, TagModel, UserModel } = require('../models')
 const { QUESTION_GROUPS, QUESTION_TYPES } = require('../constants')
@@ -42,29 +43,29 @@ const createQuestion = async ({
 }) => {
   // if no tags have been assigned, throw
   if (!tags || tags.length === 0) {
-    throw new Error('NO_TAGS_SPECIFIED')
+    throw new UserInputError('NO_TAGS_SPECIFIED')
   }
 
   // if no options have been assigned, throw
   if (QUESTION_GROUPS.WITH_OPTIONS.includes(type) && !options) {
-    throw new Error('NO_OPTIONS_SPECIFIED')
+    throw new UserInputError('NO_OPTIONS_SPECIFIED')
   }
 
   // validation for SC and MC questions
   if (QUESTION_GROUPS.CHOICES.includes(type)) {
     if (options.choices.length === 0) {
-      throw new Error('NO_CHOICES_SPECIFIED')
+      throw new UserInputError('NO_CHOICES_SPECIFIED')
     }
 
     if (solution && options.choices.length !== solution[type].length) {
-      throw new Error('INVALID_SOLUTION')
+      throw new UserInputError('INVALID_SOLUTION')
     }
   }
 
   // validation for FREE_RANGE questions
   if (type === QUESTION_TYPES.FREE_RANGE) {
     if (!options.restrictions) {
-      throw new Error('MISSING_RESTRICTIONS')
+      throw new UserInputError('MISSING_RESTRICTIONS')
     }
 
     // if at least one restriction is set, the restrictions need to be evaluated
@@ -78,7 +79,7 @@ const createQuestion = async ({
           && options.restrictions.max
           && options.restrictions.max <= options.restrictions.min)
       ) {
-        throw new Error('INVALID_RESTRICTIONS')
+        throw new UserInputError('INVALID_RESTRICTIONS')
       }
     }
   }
@@ -140,12 +141,12 @@ const modifyQuestion = async (
 
   // check if both content and options are set for a new version
   if (content ? !options : options) {
-    throw new Error('INVALID_VERSION_DEFINITION')
+    throw new UserInputError('INVALID_VERSION_DEFINITION')
   }
 
   // if no tags have been assigned, throw
   if (tags && tags.length === 0) {
-    throw new Error('NO_TAGS_SPECIFIED')
+    throw new UserInputError('NO_TAGS_SPECIFIED')
   }
 
   // get the question to be modified
@@ -154,7 +155,7 @@ const modifyQuestion = async (
     user: userId,
   }).populate(['tags'])
   if (!question) {
-    throw new Error('INVALID_QUESTION')
+    throw new UserInputError('INVALID_QUESTION')
   }
 
   if (
@@ -162,7 +163,7 @@ const modifyQuestion = async (
     && solution
     && options.choices.length !== solution[question.type].length
   ) {
-    throw new Error('INVALID_SOLUTION')
+    throw new UserInputError('INVALID_SOLUTION')
   }
 
   // if the title is set to be modified

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,6 +64,13 @@
   version "7.0.0-beta.51"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.51.tgz#27cec2df409df60af58270ed8f6aa55409ea86f6"
 
+"@babel/runtime@^7.0.0-beta.40":
+  version "7.0.0-beta.51"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.51.tgz#48b8ed18307034c6620f643514650ca2ccc0165a"
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.11.1"
+
 "@babel/template@7.0.0-beta.51":
   version "7.0.0-beta.51"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.51.tgz#9602a40aebcf357ae9677e2532ef5fc810f5fbff"
@@ -96,15 +103,87 @@
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
   dependencies:
     any-observable "^0.3.0"
 
+"@types/accepts@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
+  dependencies:
+    "@types/node" "*"
+
+"@types/events@*":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
+
+"@types/long@^3.0.32":
+  version "3.0.32"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-3.0.32.tgz#f4e5af31e9e9b196d8e5fca8a5e2e20aa3d60b69"
+
+"@types/node@*":
+  version "10.3.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.5.tgz#8423cdf6e6fb83433e489900d7600d3b61c8260c"
+
+"@types/node@^8.9.4":
+  version "8.10.20"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.20.tgz#fe674ea52e13950ab10954433a7824438aabbcac"
+
 "@types/node@^9.4.6":
   version "9.4.6"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.6.tgz#d8176d864ee48753d053783e4e463aec86b8d82e"
+
+"@types/ws@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-5.1.2.tgz#f02d3b1cd46db7686734f3ce83bdf46c49decd64"
+  dependencies:
+    "@types/events" "*"
+    "@types/node" "*"
 
 abab@^1.0.4:
   version "1.0.4"
@@ -114,7 +193,7 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-accepts@~1.3.4, accepts@~1.3.5:
+accepts@^1.3.5, accepts@~1.3.4, accepts@~1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
   dependencies:
@@ -254,11 +333,35 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-apollo-cache-control@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.1.0.tgz#0c7c9abc312dea3a60e1cb70e0869df2cd970688"
+apollo-cache-control@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.1.1.tgz#173d14ceb3eb9e7cb53de7eb8b61bee6159d4171"
   dependencies:
     graphql-extensions "^0.0.x"
+
+apollo-datasource-rest@^2.0.0-rc.2:
+  version "2.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/apollo-datasource-rest/-/apollo-datasource-rest-2.0.0-rc.2.tgz#8d5450149b49433322f1c4e78240436253890880"
+  dependencies:
+    apollo-server-caching "^2.0.0-rc.2"
+    apollo-server-env "^2.0.0-rc.2"
+    apollo-server-errors "^2.0.0-rc.2"
+    http-cache-semantics "^4.0.0"
+    lru-cache "^4.1.3"
+
+apollo-engine-reporting-protobuf@0.0.0-beta.7:
+  version "0.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.0.0-beta.7.tgz#aa8595633015e479211c8bc638c209a716a06e32"
+  dependencies:
+    protobufjs "^6.8.6"
+
+apollo-engine-reporting@0.0.0-beta.14:
+  version "0.0.0-beta.14"
+  resolved "https://registry.yarnpkg.com/apollo-engine-reporting/-/apollo-engine-reporting-0.0.0-beta.14.tgz#e7c7b8f6b9aa5208cf0472ef99ad31512c75d088"
+  dependencies:
+    apollo-engine-reporting-protobuf "0.0.0-beta.7"
+    lodash "^4.17.10"
+    requestretry "^1.13.0"
 
 apollo-link@1.2.1:
   version "1.2.1"
@@ -268,30 +371,69 @@ apollo-link@1.2.1:
     apollo-utilities "^1.0.0"
     zen-observable-ts "^0.8.6"
 
-apollo-server-core@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-1.3.6.tgz#08636243c2de56fa8c267d68dd602cb1fbd323e3"
-  dependencies:
-    apollo-cache-control "^0.1.0"
-    apollo-tracing "^0.1.0"
-    graphql-extensions "^0.0.x"
+apollo-server-caching@^2.0.0-rc.2:
+  version "2.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-2.0.0-rc.2.tgz#71220f6f5ddbf0ee752bbf60773b89b427747cbd"
 
-apollo-server-express@1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-1.3.6.tgz#2120b05021a87def44fafd846e8a0e2a32852db7"
+apollo-server-core@^2.0.0-rc.2:
+  version "2.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.0.0-rc.2.tgz#f8ce830452bcd68e1421cacd0d4432d88d7fb4d0"
   dependencies:
-    apollo-server-core "^1.3.6"
-    apollo-server-module-graphiql "^1.3.4"
+    "@types/ws" "^5.1.2"
+    apollo-cache-control "^0.1.1"
+    apollo-datasource-rest "^2.0.0-rc.2"
+    apollo-engine-reporting "0.0.0-beta.14"
+    apollo-server-env "^2.0.0-rc.2"
+    apollo-server-errors "^2.0.0-rc.2"
+    apollo-tracing "^0.2.0-beta.1"
+    apollo-upload-server "^5.0.0"
+    graphql-extensions "0.1.0-beta.13"
+    graphql-subscriptions "^0.5.8"
+    graphql-tag "^2.9.2"
+    graphql-tools "^3.0.2"
+    hash.js "^1.1.3"
+    keyv "^3.0.0"
+    lodash "^4.17.10"
+    quick-lru "^1.1.0"
+    subscriptions-transport-ws "^0.9.9"
+    ws "^5.2.0"
 
-apollo-server-module-graphiql@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/apollo-server-module-graphiql/-/apollo-server-module-graphiql-1.3.4.tgz#50399b7c51b7267d0c841529f5173e5fc7304de4"
-
-apollo-tracing@^0.1.0:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.1.3.tgz#6820c066bf20f9d9a4eddfc023f7c83ee2601f0b"
+apollo-server-env@^2.0.0-rc.2:
+  version "2.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-2.0.0-rc.2.tgz#fdf25f34053b542e8d7779f6f1526b1c6ef1f7c7"
   dependencies:
-    graphql-extensions "^0.0.x"
+    node-fetch "^2.1.2"
+
+apollo-server-errors@^2.0.0-rc.2:
+  version "2.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.0.0-rc.2.tgz#168ef5f81e164505e71ff3119094a0b3b815e8aa"
+
+apollo-server-express@2.0.0-rc.2:
+  version "2.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.0.0-rc.2.tgz#1a931cba64f301afb0fa50da43d7b00c24055b97"
+  dependencies:
+    "@types/accepts" "^1.3.5"
+    accepts "^1.3.5"
+    apollo-server-core "^2.0.0-rc.2"
+    apollo-upload-server "^5.0.0"
+    body-parser "^1.18.3"
+    cors "^2.8.4"
+    graphql-playground-middleware-express "^1.7.0"
+    type-is "^1.6.16"
+
+apollo-tracing@^0.2.0-beta.1:
+  version "0.2.0-beta.1"
+  resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.2.0-beta.1.tgz#a24bf3ab54af0ae44ae72dad3226d27cd6b06f62"
+  dependencies:
+    graphql-extensions "0.1.0-beta.0"
+
+apollo-upload-server@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/apollo-upload-server/-/apollo-upload-server-5.0.0.tgz#c953b523608313966e0c8444637f4ae8ef77d5bc"
+  dependencies:
+    "@babel/runtime" "^7.0.0-beta.40"
+    busboy "^0.2.14"
+    object-path "^0.11.4"
 
 apollo-utilities@^1.0.0, apollo-utilities@^1.0.1:
   version "1.0.8"
@@ -685,7 +827,7 @@ body-parser@1.18.2:
     raw-body "2.3.2"
     type-is "~1.6.15"
 
-body-parser@1.18.3:
+body-parser@1.18.3, body-parser@^1.18.3:
   version "1.18.3"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
   dependencies:
@@ -801,6 +943,13 @@ buffer-from@^1.0.0:
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+busboy@^0.2.14:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-0.2.14.tgz#6c2a622efcf47c57bbbe1e2a9c37ad36c7925453"
+  dependencies:
+    dicer "0.2.5"
+    readable-stream "1.1.x"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -1154,11 +1303,15 @@ core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
+core-js@^2.5.7:
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
+
 core-util-is@1.0.2, core-util-is@^1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cors@2.8.4:
+cors@2.8.4, cors@^2.8.4:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.4.tgz#2bd381f2eb201020105cd50ea59da63090694686"
   dependencies:
@@ -1185,6 +1338,13 @@ cross-env@5.2.0:
   dependencies:
     cross-spawn "^6.0.5"
     is-windows "^1.0.0"
+
+cross-fetch@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.0.0.tgz#a17475449561e0f325146cea636a8619efb9b382"
+  dependencies:
+    node-fetch "2.0.0"
+    whatwg-fetch "2.0.3"
 
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -1375,6 +1535,13 @@ detect-libc@^1.0.2:
 detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+
+dicer@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/dicer/-/dicer-0.2.5.tgz#5996c086bb33218c812c090bddc09cd12facb70f"
+  dependencies:
+    readable-stream "1.1.x"
+    streamsearch "0.1.2"
 
 diff@^3.2.0:
   version "3.4.0"
@@ -2335,12 +2502,54 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+graphql-config@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-2.0.0.tgz#daf69091055c6f675d63893a2d14c48f3fec3327"
+  dependencies:
+    graphql-import "^0.4.0"
+    graphql-request "^1.4.0"
+    js-yaml "^3.10.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.4"
+
+graphql-extensions@0.1.0-beta.0:
+  version "0.1.0-beta.0"
+  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.1.0-beta.0.tgz#2c05692a1e403274c8e3c6c1e0793d701cbdb1ab"
+  dependencies:
+    core-js "^2.5.3"
+    source-map-support "^0.5.1"
+
+graphql-extensions@0.1.0-beta.13:
+  version "0.1.0-beta.13"
+  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.1.0-beta.13.tgz#a72bf57d7ec7aaeb2601abb212b6656451e6edfd"
+  dependencies:
+    core-js "^2.5.3"
+    source-map-support "^0.5.1"
+
 graphql-extensions@^0.0.x:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.0.8.tgz#d14d6e06db466a7f90fb97d75b657ae730278b09"
   dependencies:
     core-js "^2.5.3"
     source-map-support "^0.5.1"
+
+graphql-import@^0.4.0:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/graphql-import/-/graphql-import-0.4.5.tgz#e2f18c28d335733f46df8e0733d8deb1c6e2a645"
+  dependencies:
+    lodash "^4.17.4"
+
+graphql-playground-html@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/graphql-playground-html/-/graphql-playground-html-1.6.0.tgz#6ec4d54325ab2e5352506fdb89eb37c3fc718bf8"
+  dependencies:
+    graphql-config "2.0.0"
+
+graphql-playground-middleware-express@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/graphql-playground-middleware-express/-/graphql-playground-middleware-express-1.7.0.tgz#df792b497b178657eeb01123e90991aa12066ea4"
+  dependencies:
+    graphql-playground-html "1.6.0"
 
 graphql-redis-subscriptions@1.5.0:
   version "1.5.0"
@@ -2351,13 +2560,23 @@ graphql-redis-subscriptions@1.5.0:
   optionalDependencies:
     ioredis "^3.1.2"
 
-graphql-subscriptions@0.5.8, graphql-subscriptions@^0.5.6:
+graphql-request@^1.4.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.6.0.tgz#afe87cf2a336acabb0cc2a875900202eda89f412"
+  dependencies:
+    cross-fetch "2.0.0"
+
+graphql-subscriptions@0.5.8, graphql-subscriptions@^0.5.6, graphql-subscriptions@^0.5.8:
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-0.5.8.tgz#13a6143c546bce390404657dc73ca501def30aa7"
   dependencies:
     iterall "^1.2.1"
 
-graphql-tools@3.0.2:
+graphql-tag@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.9.2.tgz#2f60a5a981375f430bf1e6e95992427dc18af686"
+
+graphql-tools@3.0.2, graphql-tools@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-3.0.2.tgz#fb79821c23b0f5d11d842c4d0c15000d856c6c8c"
   dependencies:
@@ -2468,6 +2687,13 @@ has@^1.0.1:
   dependencies:
     function-bind "^1.0.2"
 
+hash.js@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.4.tgz#8b50e1f35d51bd01e5ed9ece4dbe3549ccfa0a3c"
+  dependencies:
+    inherits "^2.0.3"
+    minimalistic-assert "^1.0.0"
+
 hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -2549,6 +2775,10 @@ html-encoding-sniffer@^1.0.2:
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
     whatwg-encoding "^1.0.1"
+
+http-cache-semantics@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#2d0069a73c36c80e3297bc3a0cadd669b78a69ce"
 
 http-errors@1.6.2, http-errors@~1.6.2:
   version "1.6.2"
@@ -2666,7 +2896,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -3042,6 +3272,10 @@ is-utf8@^0.2.0:
 is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -3426,7 +3660,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.11.0:
+js-yaml@^3.10.0, js-yaml@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -3482,6 +3716,10 @@ jsesc@^1.3.0:
 jsesc@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
+
+json-buffer@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
 
 json-parse-better-errors@^1.0.1:
   version "1.0.1"
@@ -3594,6 +3832,12 @@ jws@^3.1.5:
 kareem@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.2.1.tgz#9950809415aa3cde62ab43b4f7b919d99816e015"
+
+keyv@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
+  dependencies:
+    json-buffer "3.0.0"
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -3885,7 +4129,7 @@ lodash.values@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
 
-lodash@4.17.10, lodash@^4.17.10:
+lodash@4.17.10, lodash@^4.15.0, lodash@^4.17.10:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -3923,6 +4167,10 @@ loglevel@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
 
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -3940,6 +4188,13 @@ lowercase-keys@^1.0.0:
 lru-cache@^4.0.0, lru-cache@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
+lru-cache@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -4087,6 +4342,10 @@ mime@^1.4.1:
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+
+minimalistic-assert@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
 
 minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
@@ -4236,12 +4495,20 @@ nocache@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.0.0.tgz#202b48021a0c4cbde2df80de15a17443c8b43980"
 
+node-fetch@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.0.0.tgz#982bba43ecd4f2922a29cc186a6bbb0bb73fcba6"
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -4393,6 +4660,10 @@ object-keys@^1.0.11:
 object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object-path@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -4819,6 +5090,24 @@ prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+protobufjs@^6.8.6:
+  version "6.8.6"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.6.tgz#ce3cf4fff9625b62966c455fc4c15e4331a11ca2"
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^3.0.32"
+    "@types/node" "^8.9.4"
+    long "^4.0.0"
+
 proxy-addr@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.3.tgz#355f262505a621646b3130a728eb647e22055341"
@@ -4862,7 +5151,7 @@ qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-quick-lru@^1.0.0:
+quick-lru@^1.0.0, quick-lru@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
 
@@ -4969,6 +5258,15 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
+readable-stream@1.1.x:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
+
 readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.4.tgz#c946c3f47fa7d8eabc0b6150f4a12f69a4574071"
@@ -5023,7 +5321,7 @@ referrer-policy@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/referrer-policy/-/referrer-policy-1.1.0.tgz#35774eb735bf50fb6c078e83334b472350207d79"
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
@@ -5135,7 +5433,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@2.87.0:
+request@2.87.0, request@^2.74.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
@@ -5186,6 +5484,15 @@ request@^2.83.0:
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
+
+requestretry@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/requestretry/-/requestretry-1.13.0.tgz#213ec1006eeb750e8b8ce54176283d15a8d55d94"
+  dependencies:
+    extend "^3.0.0"
+    lodash "^4.15.0"
+    request "^2.74.0"
+    when "^3.7.7"
 
 require-ancestors@^1.0.0:
   version "1.0.0"
@@ -5681,6 +5988,10 @@ stream-combiner@~0.0.4:
   dependencies:
     duplexer "~0.1.1"
 
+streamsearch@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
+
 string-argv@^0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.0.2.tgz#dac30408690c21f3c3630a3ff3a05877bdcbd736"
@@ -5716,6 +6027,10 @@ string.prototype.matchall@^2.0.0:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     regexp.prototype.flags "^1.2.0"
+
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
 string_decoder@~1.0.3:
   version "1.0.3"
@@ -5769,7 +6084,7 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-subscriptions-transport-ws@0.9.11:
+subscriptions-transport-ws@0.9.11, subscriptions-transport-ws@^0.9.9:
   version "0.9.11"
   resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.11.tgz#76e9dd7ec1bd0aa0331eca9b7074e66ce626d13a"
   dependencies:
@@ -5994,7 +6309,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-is@~1.6.15, type-is@~1.6.16:
+type-is@^1.6.16, type-is@~1.6.15, type-is@~1.6.16:
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
   dependencies:
@@ -6215,6 +6530,10 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.19"
 
+whatwg-fetch@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+
 whatwg-fetch@>=0.10.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
@@ -6226,6 +6545,10 @@ whatwg-url@^6.4.0:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.0"
     webidl-conversions "^4.0.1"
+
+when@^3.7.7:
+  version "3.7.8"
+  resolved "https://registry.yarnpkg.com/when/-/when-3.7.8.tgz#c7130b6a7ea04693e842cdc9e7a1f2aa39a39f82"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Migrate the codebase to the Apollo Server 2.0 codebase.

**DEPENDENCIES**
- Upgrade `apollo-server-express` to 2.0.0-rc.2

**GENERAL**
- Reorganize middlewares to work with Apollo Server 2.0 `applyMiddleware`
- Rework context function for new Apollo Server 2.0 parameters
- Migrate subscriptions to native Apollo Server 2.0 implementation `installSubscriptionHandlers`
- Rework errors to be as specific as possible using the new Apollo error types (ForbiddenError etc.)

**MISC**
- Change renovate schedule to perform daily upgrades outside of working hours
- Restrict rate-limiter middleware to production deployments
