### PR TITLE
Added "Cancel Session" functionality (backend)

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -28,6 +28,7 @@ const SESSION_ACTIONS = {
   START: 'START',
   PAUSE: 'PAUSE',
   STOP: 'STOP',
+  CANCEL: 'CANCEL',
 }
 
 const Errors = {

--- a/src/integration/mutations/index.js
+++ b/src/integration/mutations/index.js
@@ -10,7 +10,6 @@ const CreateSessionMutation = loadAsString('./CreateSessionMutation.graphql')
 const ModifySessionMutation = loadAsString('./ModifySessionMutation.graphql')
 const StartSessionMutation = loadAsString('./StartSessionMutation.graphql')
 const PauseSessionMutation = loadAsString('./PauseSessionMutation.graphql')
-const CancelSessionMutation = loadAsString('./CancelSessionMutation.graphql')
 const EndSessionMutation = loadAsString('./EndSessionMutation.graphql')
 const AddFeedbackMutation = loadAsString('./AddFeedbackMutation.graphql')
 const DeleteFeedbackMutation = loadAsString('./DeleteFeedbackMutation.graphql')
@@ -48,7 +47,6 @@ module.exports = {
   ModifySessionMutation,
   StartSessionMutation,
   PauseSessionMutation,
-  CancelSessionMutation,
   EndSessionMutation,
   AddFeedbackMutation,
   DeleteFeedbackMutation,

--- a/src/integration/mutations/index.js
+++ b/src/integration/mutations/index.js
@@ -10,6 +10,7 @@ const CreateSessionMutation = loadAsString('./CreateSessionMutation.graphql')
 const ModifySessionMutation = loadAsString('./ModifySessionMutation.graphql')
 const StartSessionMutation = loadAsString('./StartSessionMutation.graphql')
 const PauseSessionMutation = loadAsString('./PauseSessionMutation.graphql')
+const CancelSessionMutation = loadAsString('./CancelSessionMutation.graphql')
 const EndSessionMutation = loadAsString('./EndSessionMutation.graphql')
 const AddFeedbackMutation = loadAsString('./AddFeedbackMutation.graphql')
 const DeleteFeedbackMutation = loadAsString('./DeleteFeedbackMutation.graphql')
@@ -47,6 +48,7 @@ module.exports = {
   ModifySessionMutation,
   StartSessionMutation,
   PauseSessionMutation,
+  CancelSessionMutation,
   EndSessionMutation,
   AddFeedbackMutation,
   DeleteFeedbackMutation,

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -93,6 +93,12 @@ const pauseSessionMutation = (parentValue, { id }, { auth }) =>
     userId: auth.sub,
   })
 
+const cancelSessionMutation = (parentValue, { id }, { auth }) =>
+  SessionMgrService.cancelSession({
+    id,
+    userId: auth.sub,
+  })
+
 const endSessionMutation = (parentValue, { id }, { auth }) =>
   SessionMgrService.endSession({
     id,
@@ -151,6 +157,7 @@ module.exports = {
   endSession: endSessionMutation,
   activateNextBlock: activateNextBlockMutation,
   pauseSession: pauseSessionMutation,
+  cancelSession: cancelSessionMutation,
   startSession: startSessionMutation,
   addFeedback: addFeedbackMutation,
   deleteFeedback: deleteFeedbackMutation,

--- a/src/schema.js
+++ b/src/schema.js
@@ -26,6 +26,7 @@ const {
   allSessions,
   createSession,
   pauseSession,
+  cancelSession,
   endSession,
   joinSession,
   runningSession,
@@ -110,6 +111,7 @@ const typeDefs = [
     modifySession(id: ID!, session: SessionModifyInput!): Session!
     modifyUser(user: User_Modify!): User!
     pauseSession(id: ID!): Session!
+    cancelSession(id: ID!): Session!
     requestAccountDeletion: String!
     resolveAccountDeletion(deletionToken: String!): String!
     requestPassword(email: String!): String!
@@ -166,6 +168,7 @@ const resolvers = {
     modifySession: requireAuth(modifySession),
     modifyUser: requireAuth(modifyUser),
     pauseSession: requireAuth(pauseSession),
+    cancelSession: requireAuth(cancelSession),
     requestAccountDeletion: requireAuth(requestAccountDeletion),
     resolveAccountDeletion: requireAuth(resolveAccountDeletion),
     requestPassword,

--- a/src/services/sessionMgr.js
+++ b/src/services/sessionMgr.js
@@ -439,6 +439,30 @@ const sessionAction = async ({ sessionId, userId }, actionType) => {
 
       break
 
+    case SESSION_ACTIONS.CANCEL:
+      // if the session is not yet running, throw an error
+      if (session.status === SESSION_STATUS.CREATED) {
+        throw new ForbiddenError('SESSION_NOT_STARTED')
+      }
+
+      // if the session was already completed, return it
+      if (session.status === SESSION_STATUS.COMPLETED) {
+        return session
+      }
+
+      // Reset any session progress, in order to revert the session to its "CREATED" state.
+      if (session.blocks.length > 0) {
+        session.activeBlock = -1
+        session.activeStep = 0
+        session.activeInstances = []
+        for (let i = 0; i < session.blocks.length; i += 1) {
+          session.blocks[i].status = QUESTION_BLOCK_STATUS.PLANNED
+        }
+      }
+      // update the session status to CREATED
+      session.status = SESSION_STATUS.CREATED
+      break
+
     default:
       throw new ForbiddenError('INVALID_SESSION_ACTION')
   }
@@ -475,6 +499,13 @@ const startSession = ({ id, userId, shortname }) =>
  */
 const pauseSession = ({ id, userId, shortname }) =>
   sessionAction({ sessionId: id, userId, shortname }, SESSION_ACTIONS.PAUSE)
+
+/**
+ * Cancel a running session, reverting it to the "CREATED" state.
+ * @param {*} param0
+ */
+const cancelSession = ({ id, userId, shortname }) =>
+  sessionAction({ sessionId: id, userId, shortname }, SESSION_ACTIONS.CANCEL)
 
 /**
  * End (complete) an existing session
@@ -666,6 +697,7 @@ module.exports = {
   activateNextBlock,
   getRunningSession,
   pauseSession,
+  cancelSession,
   deleteSessions,
   choicesToResults,
   freeToResults,


### PR DESCRIPTION
Added functionality in accordance to: https://github.com/uzh-bf/klicker-uzh/issues/12

- Reverts the session to be cancelled back to the "Created" state
- Answers, current block, block status and all other datafields get reverted to
the initial state when the session was created.


**MISC**

- This added funcionality will not work without the corresponding changes made to the Frontend of the klicker software.
