### PR TITLE
Removed runtime calculator from backend since it moved to frontend

### DIFF
--- a/src/integration/queries/AccountSummaryQuery.graphql
+++ b/src/integration/queries/AccountSummaryQuery.graphql
@@ -4,7 +4,6 @@ query AccountSummary {
     shortname
     runningSession {
       id
-      runtime
     }
   }
 }

--- a/src/integration/queries/RunningSessionQuery.graphql
+++ b/src/integration/queries/RunningSessionQuery.graphql
@@ -1,7 +1,6 @@
 query RunningSession {
   runningSession {
     id
-    runtime
     startedAt
     activeStep
     confusionTS {

--- a/src/resolvers/sessions.js
+++ b/src/resolvers/sessions.js
@@ -1,5 +1,3 @@
-const moment = require('moment')
-
 const SessionMgrService = require('../services/sessionMgr')
 const SessionExecService = require('../services/sessionExec')
 const { SessionModel, UserModel } = require('../models')
@@ -45,21 +43,6 @@ const runningSessionQuery = async (parentValue, args, { auth }) => {
 
 const joinSessionQuery = async (parentValue, { shortname }, { auth }) =>
   SessionExecService.joinSession({ shortname, auth })
-
-// calculate the session runtime
-const runtimeByPVQuery = ({ startedAt }) => {
-  const duration = moment.duration(moment().diff(startedAt))
-  const days = duration.days()
-  const hours = `0${duration.hours()}`.slice(-2)
-  const minutes = `0${duration.minutes()}`.slice(-2)
-  const seconds = `0${duration.seconds()}`.slice(-2)
-
-  if (days > 0) {
-    return `${days}d ${hours}:${minutes}:${seconds}`
-  }
-
-  return `${hours}:${minutes}:${seconds}`
-}
 
 /* ----- mutations ----- */
 const createSessionMutation = (
@@ -143,7 +126,6 @@ module.exports = {
   session: sessionQuery,
   sessionByPV: sessionByPVQuery,
   sessionsByPV: sessionsByPVQuery,
-  runtimeByPV: runtimeByPVQuery,
 
   // mutations
   createSession: createSessionMutation,

--- a/src/schema.js
+++ b/src/schema.js
@@ -38,7 +38,6 @@ const {
   updateSessionSettings,
   activateNextBlock,
   activateBlockById,
-  runtimeByPV,
   session,
   modifySession,
   deleteSessions,
@@ -271,7 +270,6 @@ const resolvers = {
   },
   Session: {
     user,
-    runtime: runtimeByPV,
   },
   Session_QuestionBlock: {
     instances: questionInstancesByPV,

--- a/src/types/Session.js
+++ b/src/types/Session.js
@@ -57,7 +57,6 @@ module.exports = `
     activeBlock: Int!
     activeStep: Int!
     execution: Int
-    runtime: String
 
     status: Session_Status!
     settings: Session_Settings!


### PR DESCRIPTION
Removed runtime calculator and the runtime field from all types which contained it since the runtime is calculated in the frontend now.